### PR TITLE
Update exposures table only for current night

### DIFF
--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -439,14 +439,17 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, cameras=None):
                                         error_colors=error_colors)
 
 
-def write_tables(indir, outdir):
+def write_tables(indir, outdir, expnights=None):
     '''
     Parses directory for available nights, exposures to generate
     nights and exposures tables
     
     Args:
         indir : directory of nights
-        outdir : directory where to write nights table 
+        outdir : directory where to write nights table
+
+    Options:
+        expnights (list) : only update exposures tables for these nights
     '''
     import re
     from astropy.table import Table
@@ -503,7 +506,7 @@ def write_tables(indir, outdir):
     nightsfile = os.path.join(outdir, 'nights.html')
     web_tables.write_nights_table(nightsfile, exposures)
 
-    web_tables.write_exposures_tables(indir, outdir, exposures)
+    web_tables.write_exposures_tables(indir, outdir, exposures, nights=expnights)
     
 
 def write_nights_summary(indir, last):

--- a/py/nightwatch/script.py
+++ b/py/nightwatch/script.py
@@ -179,7 +179,7 @@ def main_monitor(options=None):
                 run.make_plots(infile=qafile, basedir=args.plotdir, preprocdir=outdir, logdir=outdir,
                                cameras=cameras)
 
-                run.write_tables(args.outdir, args.plotdir)
+                run.write_tables(args.outdir, args.plotdir, expnights=[night,])
 
                 time_end = time.time()
                 dt = (time_end - time_start) / 60
@@ -233,7 +233,7 @@ def main_run(options=None):
     run.make_plots(qafile, args.outdir, preprocdir=expdir, logdir=expdir, cameras=cameras)
 
     print('{} Updating night/exposure summary tables'.format(time.strftime('%H:%M')))
-    run.write_tables(args.outdir, args.outdir)
+    run.write_tables(args.outdir, args.outdir, expnights=[night,])
 
     dt = (time.time() - time_start) / 60.0
     print('{} Done ({:.1f} min)'.format(time.strftime('%H:%M'), dt))

--- a/py/nightwatch/script.py
+++ b/py/nightwatch/script.py
@@ -107,6 +107,7 @@ def main_monitor(options=None):
             continue
 
         night, expid = expdir.split('/')[-2:]
+        night = int(night)
         rawfile = os.path.join(expdir, 'desi-{}.fits.fz'.format(expid))
         if expdir not in processed and os.path.exists(rawfile):
             processed.add(expdir)

--- a/py/nightwatch/webpages/amp.py
+++ b/py/nightwatch/webpages/amp.py
@@ -8,6 +8,7 @@ from ..plots.amp import plot_amp_qa
 from ..thresholds import pick_threshold_file, get_thresholds
 
 import os 
+from desiutil.log import get_logger
 
 def write_amp_html(outfile, data, header):
     '''Write CCD amp QA webpage
@@ -20,7 +21,7 @@ def write_amp_html(outfile, data, header):
     Returns:
         html_components dict with keys 'script', 'div' from bokeh
     '''
-    
+    log = get_logger() 
     night = header['NIGHT']
     expid = header['EXPID']
     if 'OBSTYPE' in header :

--- a/py/nightwatch/webpages/summary.py
+++ b/py/nightwatch/webpages/summary.py
@@ -13,6 +13,8 @@ from ..plots.spectra import plot_spectra_input
 from . import camfiber
 from ..thresholds import pick_threshold_file, get_thresholds
 
+from desiutil.log import get_logger
+
 import bokeh
 from bokeh.embed import components
 from bokeh.layouts import gridplot, layout
@@ -27,7 +29,7 @@ def get_summary_plots(qadata, qprocdir=None):
     Returns:
         dict of html_components to embed in a summary webpage
     '''
-
+    log = get_logger()
     header = qadata['HEADER']
     night = header['NIGHT']
     expid = header['EXPID']

--- a/py/nightwatch/webpages/tables.py
+++ b/py/nightwatch/webpages/tables.py
@@ -2,7 +2,7 @@
 Pages summarizing QA results
 """
 
-import os, json, re
+import os, json, re, time
 from collections import OrderedDict, Counter
 
 import numpy as np
@@ -169,6 +169,8 @@ def write_exposures_tables(indir, outdir, exposures, nights=None):
         nights = np.unique(exposures['NIGHT'])
 
     for night in nights:
+        log.debug('{} Generating exposures table for {}'.format(
+            time.asctime(), night))
         ii = (exposures['NIGHT'] == night)
         explist = list()
         
@@ -239,6 +241,6 @@ def write_exposures_tables(indir, outdir, exposures, nights=None):
         with open(outfile, 'w') as fx:
             fx.write(html)
 
-        _write_expid_links(outdir, exposures, nights)
-
+    #- Update expid and night links only once at the end
+    _write_expid_links(outdir, exposures, nights)
     _write_night_links(outdir)

--- a/py/nightwatch/webpages/tables.py
+++ b/py/nightwatch/webpages/tables.py
@@ -171,7 +171,7 @@ def write_exposures_tables(indir, outdir, exposures, nights=None):
     for night in nights:
         log.debug('{} Generating exposures table for {}'.format(
             time.asctime(), night))
-        ii = (exposures['NIGHT'] == night)
+        ii = (exposures['NIGHT'] == int(night))
         explist = list()
         
         night_exps = exposures[ii]


### PR DESCRIPTION
With `nightwatch monitor` and `nightwatch run`, only update the exposures tables for the current night, while retaining the ability for `nightwatch tables` to update the exposures tables for all nights.

Fixes an indentation bug that previously resulted in O(N^2) performance by writing the expid navigation links for every night on every iteration of writing the exposures table for an individual night.  That only needs to be done once at the end. 

Also fixes a few missing `desiutil.log` imports that otherwise crash nightwatch when running on exposures without OBSTYPE.

@julienguy please review.