### PR TITLE
CMX updates

### DIFF
--- a/py/nightwatch/io.py
+++ b/py/nightwatch/io.py
@@ -93,7 +93,14 @@ def get_night_expid(filename):
         return int(hdr['NIGHT']), int(hdr['EXPID'])
 
     #- not found there, try HDU 1 before giving up
-    hdr = fitsio.read_header(filename, 1)
+    try:
+        hdr = fitsio.read_header(filename, 1)
+    except OSError:
+        from desiutil.log import get_logger
+        log = get_logger()
+        log.error('fitsio error reading HDU 1; trying HDU 2 before giving up')
+        hdr = fitsio.read_header(filename, 2)
+
     if 'NIGHT' in hdr and 'EXPID' in hdr:
         return int(hdr['NIGHT']), int(hdr['EXPID'])
 

--- a/py/nightwatch/qa/runner.py
+++ b/py/nightwatch/qa/runner.py
@@ -20,6 +20,7 @@ from .traceshift import QATraceShift
 from .psf import QAPSF
 from .fiberflat import QAFiberflat
 from .snr import QASNR
+from ..run import timestamp
 
 class QARunner(object):
 
@@ -82,7 +83,7 @@ class QARunner(object):
         results = dict()
         for qa in self.qalist:
             if qa.valid_obstype(obstype):
-                log.debug('Running {} {}'.format(qa, qa.output_type))
+                log.info('{} Running {} {}'.format(timestamp(), qa, qa.output_type))
                 qa_results = None
                 try:
                     qa_results = qa.run(indir)
@@ -167,6 +168,7 @@ class QARunner(object):
                 break
 
             #- To do: consider propagating header from indir/desi*.fits.fz
+            log.info('{} Writing {}'.format(timestamp(), outfile))
             with fitsio.FITS(outfile, 'rw', clobber=True) as fx:
                 fx.write(np.zeros(3, dtype=float), extname='PRIMARY', header=hdr)
                 for qatype, qatable in results.items():

--- a/py/nightwatch/qa/snr.py
+++ b/py/nightwatch/qa/snr.py
@@ -128,7 +128,8 @@ class QASNR(QA):
                 
                 rflux = swf/(sw+(sw==0))
                 # interpolate over masked pixels
-                rflux[sw==0] = np.interp(self.rwave[sw==0],self.rwave[sw>0],rflux[sw>0],left=0,right=0)
+                if np.count_nonzero(sw>0) > 2:
+                    rflux[sw==0] = np.interp(self.rwave[sw==0],self.rwave[sw>0],rflux[sw>0],left=0,right=0)
 
                 fluxunits = 1e-17 * units.erg / units.s / units.cm**2 / units.Angstrom
                 for c in ["G","R","Z"] :

--- a/py/nightwatch/qa/snr.py
+++ b/py/nightwatch/qa/snr.py
@@ -104,25 +104,41 @@ class QASNR(QA):
                     stars       = (desi_target & desi_mask.mask('STD_WD|STD_FAINT|STD_BRIGHT')) != 0
                     qsos        = (desi_target & desi_mask.QSO) != 0
             
+            sw  = np.zeros(self.rwave.size)
+            swf = np.zeros(self.rwave.size)
+
+            #- we need a ridiculously large array to cover the r filter, but precache
+            #- what wavelength ranges matter for each band
+            iiband = dict()
+            for c in ["B", "R", "Z"]:
+                if c in qframes:
+                    qframe = qframes[c]
+                    iiband[c] = (qframe.wave[0][0] < self.rwave)
+                    iiband[c] &= (self.rwave < qframe.wave[0][-1])
+
             for f,fiber in enumerate(fmap["FIBER"]) :
-                
                 dico={"NIGHT":night,"EXPID":expid,"SPECTRO":spectro,"FIBER":fiber}
                 for k in ["FLUX_G","FLUX_R","FLUX_Z"] :
                     dico[k]=fmap[k][f]
                 
                 photsys=fmap["PHOTSYS"][f]
-                
-                sw  = np.zeros(self.rwave.size)
-                swf = np.zeros(self.rwave.size)
+
+                #- clear previous fiber results
+                sw  *= 0.0
+                swf *= 0.0
                 
                 for c in ["B","R","Z"] :
                     
                     if c in qframes :
                         qframe=qframes[c]
                         dico["SNR_"+c] = np.median(qframe.flux[f] * np.sqrt(qframe.ivar[f]))
-                        cf , cw = resample_flux(self.rwave,qframe.wave[f],qframe.flux[f],qframe.ivar[f])
-                        sw  += cw
-                        swf += cw*cf
+                        ### cf , cw = resample_flux(self.rwave,qframe.wave[f],qframe.flux[f],qframe.ivar[f])
+                        ### sw  += cw
+                        ### swf += cw*cf
+                        ii = iiband[c]
+                        cf, cw = resample_flux(self.rwave[ii],qframe.wave[f],qframe.flux[f],qframe.ivar[f])
+                        sw[ii]  += cw
+                        swf[ii] += cw*cf
                     else :
                         dico["SNR_"+c] = 0.
                 

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -117,10 +117,13 @@ def find_latest_expdir(basedir, processed, startdate=None):
     log.debug('{} Looking for exposures in {}'.format(timestamp(), nightdir))
 
     spectrofiles = sorted(glob.glob(nightdir + '/*/desi*.fits.fz'))
-    log.debug('{} found {} desi spectro files {}..{}'.format(
-        timestamp(), len(spectrofiles),
-        os.path.basename(spectrofiles[0]),
-        os.path.basename(spectrofiles[1])))
+    if len(spectrofiles) > 0:
+        log.debug('{} found {} desi spectro files though {}'.format(
+            timestamp(), len(spectrofiles),
+            $os.path.basename(spectrofiles[-1])))
+    else:
+        log.debug('{} no new spectro files yet'.format(timestamp))
+        return None
 
     for filename in spectrofiles:
         dirname = os.path.dirname(filename)

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -2,6 +2,7 @@ import os, re, time
 import multiprocessing as mp
 import subprocess
 import time
+import glob
 
 import fitsio
 import numpy as np
@@ -115,42 +116,20 @@ def find_latest_expdir(basedir, processed, startdate=None):
     night = dirname
     log.debug('{} Looking for exposures in {}'.format(timestamp(), nightdir))
 
-    # spectrofiles = sorted(glob.glob(nightdir + '/*/desi*.fits.fz'))
+    spectrofiles = sorted(glob.glob(nightdir + '/*/desi*.fits.fz'))
+    log.debug('{} found {} desi spectro files {}..{}'.format(
+        timestamp(), len(spectrofiles),
+        os.path.basename(spectrofiles[0]),
+        os.path.basename(spectrofiles[1])))
 
-    dirlist = sorted(os.listdir(nightdir))
-    log.debug('{} Found {}'.format(timestamp(), ' '.join(dirlist)))
-    procset = ' '.join(sorted([os.path.basename(x) for x in processed]))
-    log.debug('{} Already processed {}'.format(
-        timestamp(), procset))
-    for dirname in dirlist:
-        expdir = os.path.join(nightdir, dirname)
-        if expdir in processed:
-            ### log.debug('Already processed {}'.format(expdir))
-            continue
-
-        expid = dirname
-        datafilename = os.path.join(expdir, 'desi-{}.fits.fz'.format(expid))
-        #- 20200214 HACK
-        #- sometimes the link is written slightly before the desi file
-        #- appears, so try a few times before giving up
-        for i in range(3):
-            if os.path.isfile(datafilename):
-                log.debug('{} selected {}'.format(timestamp(), datafilename))
-                return expdir
-            else:
-                log.debug('no {}/{}/desi*.fits.fz; try again in 30 sec'.format(
-                    night, expid))
-                time.sleep(30)
-
-        #- else on the for loop means it finished without finding a desi file
-        else:
-            log.debug('Skipping {}/{} with no desi*.fits.fz'.format(night, expid))
-            processed.add(expdir)  #- so that we won't check again
-
-    #- else on foor loop over directories means no new exposures found
+    for filename in spectrofiles:
+        dirname = os.path.dirname(filename)
+        if dirname not in processed:
+            log.debug('{} selected {}'.format(timestamp(), filename))
+            return dirname
     else:
-        log.debug('{} No new exposures found'.format(timestamp()))
-        return None  #- no basename/YEARMMDD directory was found
+        log.debug('{} no new spectro files found'.format(timestamp()))
+        return None
 
 def which_cameras(rawfile):
     '''

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -120,7 +120,7 @@ def find_latest_expdir(basedir, processed, startdate=None):
     if len(spectrofiles) > 0:
         log.debug('{} found {} desi spectro files though {}'.format(
             timestamp(), len(spectrofiles),
-            $os.path.basename(spectrofiles[-1])))
+            os.path.basename(spectrofiles[-1])))
     else:
         log.debug('{} no new spectro files yet'.format(timestamp))
         return None

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -122,7 +122,7 @@ def find_latest_expdir(basedir, processed, startdate=None):
             timestamp(), len(spectrofiles),
             os.path.basename(spectrofiles[-1])))
     else:
-        log.debug('{} no new spectro files yet'.format(timestamp))
+        log.debug('{} no new spectro files yet'.format(timestamp()))
         return None
 
     for filename in spectrofiles:

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -484,9 +484,10 @@ def write_tables(indir, outdir, expnights=None):
                     qafile = os.path.join(expdir, 'qa-{:08d}.fits'.format(expid))
                     
                     #- gets the list of failed qprocs for each expid
-                    preproc_cams = [i.split("-")[1] for i in os.listdir(expdir) 
+                    expfiles = os.listdir(expdir)
+                    preproc_cams = [i.split("-")[1] for i in expfiles
                                     if re.match(r'preproc-.*-.*.fits', i)]
-                    log_cams = [i.split("-")[1] for i in os.listdir(expdir) if re.match(r'.*\.log', i)]
+                    log_cams = [i.split("-")[1] for i in expfiles if re.match(r'.*\.log', i)]
                     qfails = [i for i in log_cams if i not in preproc_cams]
                     
                     if os.path.exists(qafile):

--- a/py/nightwatch/script.py
+++ b/py/nightwatch/script.py
@@ -99,8 +99,8 @@ def main_monitor(options=None):
     #- TODO: figure out a way to print how many nights are being skipped before startdate
     while True:        
 
-        if os.path.exists('nightwatch.stop'):
-            print("Found nightwatch.stop file; exiting now")
+        if os.path.exists('stop.nightwatch'):
+            print("Found stop.nightwatch file; exiting now")
             sys.exit(0)
 
         if args.catchup:


### PR DESCRIPTION
In prep for running nightwatch at NERSC (instead of just syncing output from KPNO), bringing in some changes made at KPNO to adapt to CMX data:
  * work around fitsio 1.x vs. 0.9.x incompatibility with blank keywords
  * monitor for {expid}/desi*.fits.fz instead of just new {expid}/ directory
  * faster SNR QA
  * more logging

This has been tested at KPNO for months, so I plan to self-merge to be able to deploy these changes at NERSC too.