### PR TITLE
Posacc

### DIFF
--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -160,14 +160,14 @@ def plot_camfib_posacc(pcd,attribute,percentiles={},
     metric = np.array(pcd.data.get(attribute), copy=True)
     metric = metric[np.where(metric>0)] #removed nan values
     pmin, pmax = np.percentile(metric, (0, 95))
-    hist_x_range = (pmin * 0.99, pmax * 1.01)
+    #hist_x_range = (pmin * 0.99, pmax * 1.01)
 
     if attribute == 'BLIND':
         title = "Max Blind Move: {:.2f}um".format(np.max(metric))
-        upper_cmap = 200
+        zmax = 200
     elif attribute == 'FINAL_MOVE':
         title = 'RMS Final Move: {:.2f}um'.format(np.sqrt(np.square(metric).mean()))
-        upper_cmap = 30
+        zmax = 30
 
 
     attr_formatted_str = "@" + attribute + '{(0.00 a)}'
@@ -185,12 +185,12 @@ def plot_camfib_posacc(pcd,attribute,percentiles={},
         fig_x_range = figs_list[0].x_range
         fig_y_range = figs_list[0].y_range
 
+    hist_x_range = (pmin * 0.99, zmax)
     c = '' # So not to change plot_fibers_focalplane code
     fig, hfig = plot_fibers_focalplane(pcd, attribute,cam=c, 
                         percentile=percentiles.get(c),
                         palette = bp.Magma256,
-                        upper_cmap=upper_cmap,
-                        title=title,
+                        title=title,zmin=0, zmax=zmax,
                         tools=tools, hist_x_range=hist_x_range,
                         fig_x_range=fig_x_range, fig_y_range=fig_y_range,
                         colorbar=True)

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -85,6 +85,120 @@ def plot_camfib_focalplane(cds, attribute, cameras, percentiles={},
     return figs_list, hfigs_list
 
 
+def plot_camfib_fot(cds, attribute, cameras, percentiles={},
+                      zmaxs={}, zmins={}, titles={},
+                      tools='pan,box_zoom,reset'):
+    '''
+    ARGS:
+        cds : ColumnDataSource of data
+        attribute : string corresponding to column name in DATA
+        cameras : list of string representing unique camera values
+
+    Options:
+        percentiles : dictionary of cameras corresponding to (min,max)
+            to clip data for histogram
+        zmaxs : dictionary of cameras corresponding to hardcoded max values
+            to clip data for histogram
+        zmins : dictionary of cameras corresponding to hardcoded min values
+            to clip data for histogram
+        titles : dictionary of titles per camera for a group of camfiber plots
+            where key-value pairs represent a camera-attribute plot title
+        tools, tooltips : supported plot interactivity features
+    '''
+    if attribute not in list(cds.data.keys()):
+        raise ValueError('{} not in cds.data.keys'.format(attribute))
+
+    metric = np.array(cds.data.get(attribute), copy=True)
+
+    #- adjusts for outliers on the full scale
+    #- change back to (2.5, 97.5) for the middle 95% for real data...?
+    pmin, pmax = np.percentile(metric, (0, 95))
+
+    #- common scale for all histograms for this metric
+    hist_x_range = (pmin * 0.99, pmax * 1.01)
+
+    #- for hover tool
+    attr_formatted_str = "@" + attribute + '{(0.00 a)}'
+    tooltips = [("FIBER", "@FIBER"), ("(X, Y)", "(@X, @Y)"),
+                (attribute, attr_formatted_str)]
+
+    figs_list = []
+
+    for i in range(len(cameras)):
+        c = cameras[i]
+
+        first_x_range = bokeh.models.Range1d(-420, 420)
+        first_y_range = bokeh.models.Range1d(-420, 420)
+
+        #- shared ranges to support linked features
+        if not figs_list:
+            fig_x_range = first_x_range
+            fig_y_range = first_y_range
+        else:
+            fig_x_range = figs_list[0].x_range
+            fig_y_range = figs_list[0].y_range
+
+        fig, hfig = plot_fibers_focalplane(cds, attribute, cam=c,
+                        percentile=percentiles.get(c),
+                        zmin=zmins.get(c), zmax=zmaxs.get(c),
+                        title=titles.get(c, {}).get(attribute),
+                        palette = list(np.flip(bp.YlGnBu[5])),
+                        tools=tools, hist_x_range=hist_x_range,
+                        fig_x_range=fig_x_range, fig_y_range=fig_y_range,
+                        colorbar=False, on_target=True)
+
+        figs_list.append(fig)
+
+
+    return figs_list
+
+def plot_camfib_posacc(pcd,attribute,percentiles={},
+                      tools='pan,box_zoom,reset'):
+
+    figs_list = []
+    hfigs_list = []
+    metric = np.array(pcd.data.get(attribute), copy=True)
+    metric = metric[np.where(metric>0)] #removed nan values
+    pmin, pmax = np.percentile(metric, (0, 95))
+    hist_x_range = (pmin * 0.99, pmax * 1.01)
+
+    if attribute == 'BLIND':
+        title = "Max Blind Move: {:.2f}um".format(np.max(metric))
+        upper_cmap = 200
+    elif attribute == 'FINAL_MOVE':
+        title = 'RMS Final Move: {:.2f}um'.format(np.sqrt(np.square(metric).mean()))
+        upper_cmap = 30
+
+
+    attr_formatted_str = "@" + attribute + '{(0.00 a)}'
+    tooltips = [("FIBER", "@FIBER"), ("(X, Y)", "(@X, @Y)"),
+                (attribute, attr_formatted_str)]
+
+
+    first_x_range = bokeh.models.Range1d(-420, 420)
+    first_y_range = bokeh.models.Range1d(-420, 420)
+
+    if not figs_list:
+        fig_x_range = first_x_range
+        fig_y_range = first_y_range
+    else:
+        fig_x_range = figs_list[0].x_range
+        fig_y_range = figs_list[0].y_range
+
+    c = '' # So not to change plot_fibers_focalplane code
+    fig, hfig = plot_fibers_focalplane(pcd, attribute,cam=c, 
+                        percentile=percentiles.get(c),
+                        palette = bp.Magma256,
+                        upper_cmap=upper_cmap,
+                        title=title,
+                        tools=tools, hist_x_range=hist_x_range,
+                        fig_x_range=fig_x_range, fig_y_range=fig_y_range,
+                        colorbar=True)
+
+    figs_list.append(fig)
+    hfigs_list.append(hfig)
+    return figs_list, hfigs_list
+
 
 def plot_per_fibernum(cds, attribute, cameras, titles={},
         tools='pan,box_zoom,tap,reset', width=700, height=80,

--- a/py/nightwatch/plots/fiber.py
+++ b/py/nightwatch/plots/fiber.py
@@ -23,8 +23,8 @@ def plot_fibers_focalplane(source, name, cam='',
                 camcolors=dict(B='steelblue', R='firebrick', Z='green'),
                 width=250, height=270, zmin=None, zmax=None,
                 percentile=None, title=None, hist_x_range=None,
-                fig_x_range=None, fig_y_range=None,
-                colorbar=False, palette=None, plot_hist=True,
+                upper_cmap = None, fig_x_range=None, fig_y_range=None,
+                colorbar=False, palette=None, plot_hist=True, on_target=False,
                 tools=['pan','box_select','reset','tap'], tooltips=None):
     '''
     ARGS:
@@ -40,24 +40,28 @@ def plot_fibers_focalplane(source, name, cam='',
         title : title for the plot
         tools : string of supported features for the plot
         tooltips : hovertool info
+        upper_cmap : max value for cmap (used primarily for pos acc plots)
         hist_x_range, fig_x_range, fig_y_range : figure ranges to support linking
         palette : bokeh palette of colors
         colorbar : boolean value to add a color bar
         plot_hist : boolean value to add a histogram
+        on_target : boolean value to make fibers on target plot
 
 
     Generates a focal plane plot with data per fiber color-coded based on its value
     Generates a histogram of NAME values per fiber
     '''
-    full_metric = np.array(source.data.get(name), copy=True)
+    full_metric =np.array(source.data.get(name), copy=True)
+
     #- adjusts for outliers on the full scale
     pmin_full, pmax_full = np.percentile(full_metric, (0, 95))
 
     #- Generate colors for both plots
     if not palette:
         palette = np.array(bp.RdYlBu[11])
-    mapper = linear_cmap(name, palette, low=pmin_full, high=pmax_full, nan_color='gray')
-
+    if not upper_cmap:
+        upper_cmap = pmax_full
+    mapper = linear_cmap(name, palette, low=pmin_full, high=upper_cmap, nan_color='gray')
     #- Focal plane colored scatter plot
     fig = bk.figure(width=width, height=height, title=title, tools=tools,
                     x_range=fig_x_range, y_range=fig_y_range)
@@ -96,6 +100,11 @@ def plot_fibers_focalplane(source, name, cam='',
                     line_color=color, line_alpha=0.5, line_width=2)
         fig.text([-350,], [350,], [cam.upper(),],
             text_align='center', text_baseline='middle')
+    if on_target:
+        d = source.data['ON_TARGET'][booleans_metric]
+        on_fib = len(d[d == 1])
+        fig.text([-350,], [-400,], ['{}'.format(on_fib),],
+                text_align='center',text_baseline='middle')
 
     #- style visual attributes of the figure
     fig.xgrid.grid_line_color = None
@@ -139,7 +148,6 @@ def plot_fibers_focalplane(source, name, cam='',
             metric = np.clip(metric, pmin, pmax)
         if zmin or zmax:
             metric = np.clip(metric, zmin, zmax)
-
     hfig = plot_histogram(metric, title=name, width=width, x_range=hist_x_range, num_bins=50,
                          palette=mapper['transform'].palette, low=pmin_full, high=pmax_full)
 

--- a/py/nightwatch/plots/fiber.py
+++ b/py/nightwatch/plots/fiber.py
@@ -23,7 +23,7 @@ def plot_fibers_focalplane(source, name, cam='',
                 camcolors=dict(B='steelblue', R='firebrick', Z='green'),
                 width=250, height=270, zmin=None, zmax=None,
                 percentile=None, title=None, hist_x_range=None,
-                upper_cmap = None, fig_x_range=None, fig_y_range=None,
+                fig_x_range=None, fig_y_range=None,
                 colorbar=False, palette=None, plot_hist=True, on_target=False,
                 tools=['pan','box_select','reset','tap'], tooltips=None):
     '''
@@ -40,7 +40,6 @@ def plot_fibers_focalplane(source, name, cam='',
         title : title for the plot
         tools : string of supported features for the plot
         tooltips : hovertool info
-        upper_cmap : max value for cmap (used primarily for pos acc plots)
         hist_x_range, fig_x_range, fig_y_range : figure ranges to support linking
         palette : bokeh palette of colors
         colorbar : boolean value to add a color bar
@@ -59,9 +58,9 @@ def plot_fibers_focalplane(source, name, cam='',
     #- Generate colors for both plots
     if not palette:
         palette = np.array(bp.RdYlBu[11])
-    if not upper_cmap:
-        upper_cmap = pmax_full
-    mapper = linear_cmap(name, palette, low=pmin_full, high=upper_cmap, nan_color='gray')
+    if not zmax:
+        zmax = pmax_full
+    mapper = linear_cmap(name, palette, low=pmin_full, high=zmax, nan_color='gray')
     #- Focal plane colored scatter plot
     fig = bk.figure(width=width, height=height, title=title, tools=tools,
                     x_range=fig_x_range, y_range=fig_y_range)

--- a/py/nightwatch/qa/runner.py
+++ b/py/nightwatch/qa/runner.py
@@ -39,7 +39,7 @@ class QARunner(object):
         '''TODO: document'''
         log = desiutil.log.get_logger()
         log.debug('Running QA in {}'.format(indir))
-
+        print('here qa.runner', indir)
         preprocfiles = sorted(glob.glob('{}/preproc-*.fits'.format(indir)))
         if len(preprocfiles) == 0:
             log.error('No preproc files found in {}'.format(indir))

--- a/py/nightwatch/webpages/camfiber.py
+++ b/py/nightwatch/webpages/camfiber.py
@@ -35,7 +35,7 @@ def write_camfiber_html(outfile, data, header):
     TITLES = {'INTEG_RAW_FLUX':'Integrated Raw Counts', 'MEDIAN_RAW_FLUX':'Median Raw Counts',
               'MEDIAN_RAW_SNR':'Median Raw S/N', 'INTEG_CALIB_FLUX':'Integrated Calibrated Flux',
               'MEDIAN_CALIB_FLUX':'Median Calibrated Flux', 'MEDIAN_CALIB_SNR':'Median Calibrated S/N',
-              'ON_TARGET': 'Fibers On Target'}
+              'ON_TARGET': 'Fibers With Median (S/N) > 1'}
     TITLESPERCAM = {'B':TITLES}
     TOOLS = 'pan,box_zoom,tap,reset'
 

--- a/py/nightwatch/webpages/templates/posacc.html
+++ b/py/nightwatch/webpages/templates/posacc.html
@@ -1,0 +1,5 @@
+{% extends "camfiber.html" %}
+
+{% block plot_type %}
+<p><strong>Positioner Accuracy QA metrics vs. x,y location on the focal plane</strong></p>
+{% endblock %}

--- a/py/nightwatch/webpages/templates/qabase.html
+++ b/py/nightwatch/webpages/templates/qabase.html
@@ -28,6 +28,7 @@
       <ul class="dropdown-content">
         <a id="camfiber" href="{% for i in range(num_dirs) %}../{% endfor %}{{night}}/{{zexpid}}/qa-camfiber-{{ zexpid }}.html">fibernum</a>
         <a id="focalplane" href="{% for i in range(num_dirs) %}../{% endfor %}{{night}}/{{zexpid}}/qa-camfiber-{{ zexpid }}-focalplane_plots.html">focalplane</a>
+	<a id="positioning" href="{% for i in range(num_dirs) %}../{% endfor %}{{night}}/{{zexpid}}/qa-camfiber-{{ zexpid }}-posacc_plots.html">positioning</a>
       </ul>
   </li>
 


### PR DESCRIPTION
Added plots to a new page under camfiber that shows: Fibers on Target and the Blind and Final positioner accuracy for a given exposure.

Files added:
* /webpages/templates/posacc.html: Just a copy of the focalplane.html for this new page

Modified Files:
* run.py: Under `run_qproc()`, added snippet to copy the coordinates file associated with the exposure into the output dir for nightwatch
* /webpages/templates/qabase.html: Added label for `positioning` in drop down menu camfiber
* /plots/fiber.py: Added arguments to `plot_fibers_focalplane()`:
** `on_target` for additional text on Fibers on Target plots
** `upper_cmap` to provide max in colormap
* /plots/camfiber.py: Added `plot_camfib_fot()` and `plot_camfib_posacc()`, based on `plot_camfib_focalplane()` with some small differences.
* /webpages/camfiber.py: 
 * Calls `plot_camfib_fot()` and `plot_camfib_posacc()`. 
 * Added `write_posacc_plots()`
 * Added `get_posacc_cd()` which gets the ColumnDataSource from the coordinates file.