### PR TITLE
Adding surveyqa

### DIFF
--- a/py/nightwatch/io.py
+++ b/py/nightwatch/io.py
@@ -15,6 +15,9 @@ import bokeh
 import urllib.request
 from pathlib import PurePath
 
+import warnings
+warnings.filterwarnings('once', category=RuntimeWarning)
+
 def read_qa(filename):
     '''
     Read QA data from qa-EXPID.fits file

--- a/py/nightwatch/io.py
+++ b/py/nightwatch/io.py
@@ -223,7 +223,7 @@ def get_surveyqa_data(infile, name_dict, rawdir, program=True):
         infile: (str) path to file containing surveyqa data
         name_dict: dictionary with column equivalents
             Must have equivalents for AIRMASS, SKY, SEEING, TRANSP, RA, DEC, MJD, NIGHT, EXPID.
-        rawdir: directory containing raw data files
+        rawdir: directory containing raw data files.
     Options:
         program: whether or not to use hardcoded information to assign programs to tileids, default=True
     Returns: two tables, one with aggregated data by exposure, and one with the finer scaled data.'''

--- a/py/nightwatch/io.py
+++ b/py/nightwatch/io.py
@@ -236,12 +236,10 @@ def get_surveyqa_data(infile, name_dict, rawdir, program=True):
     new_table["HOURANGLE"] = LST - new_table["RA"]
     
     def change_range(i):
-
         if i > 180:
-           return i - 360
+            return i - 360
         if i < -180:
-           return 360 + i
-
+            return 360 + i
         return i
 
     new_table["HOURANGLE"] = [change_range(i) for i in new_table["HOURANGLE"]]

--- a/py/nightwatch/io.py
+++ b/py/nightwatch/io.py
@@ -250,9 +250,9 @@ def get_surveyqa_data(infile, name_dict, rawdir, program=True):
     table_min = table_by_expid.groups.aggregate(np.nanmin)
 
     exposures = Table()
-    for attr in ["AIRMASS", "SKY", "SEEING", "TRANSP"]:
+    for attr in ["AIRMASS", "SKY", "SEEING", "TRANSP", "MJD"]:
         exposures[attr] = table_med[attr]
-    for attr in ['RA', "DEC", "MJD", "NIGHT", "EXPID", "HOURANGLE"]:
+    for attr in ['RA', "DEC", "NIGHT", "EXPID", "HOURANGLE"]:
         exposures[attr] = table_min[attr]
         
     flavors = []

--- a/py/nightwatch/io.py
+++ b/py/nightwatch/io.py
@@ -148,12 +148,12 @@ def get_surveyqa_data(infile, name_dict, rawdir, program=True):
     
     table_by_expid = new_table.group_by('EXPID')
     
-    table_mean = table_by_expid.groups.aggregate(np.nanmean)
+    table_med = table_by_expid.groups.aggregate(np.nanmedian)
     table_min = table_by_expid.groups.aggregate(np.nanmin)
 
     exposures = Table()
     for attr in ["AIRMASS", "SKY", "SEEING", "TRANSP"]:
-        exposures[attr] = table_mean[attr]
+        exposures[attr] = table_med[attr]
     for attr in ['RA', "DEC", "MJD", "NIGHT", "EXPID", "HOURANGLE"]:
         exposures[attr] = table_min[attr]
         

--- a/py/nightwatch/io.py
+++ b/py/nightwatch/io.py
@@ -2,10 +2,19 @@
 I/O routines for QA
 '''
 
-import os
+import os, sys, shutil
+import re
+from os import walk
 import glob
 import numpy as np
 import fitsio
+import json
+from astropy.io import fits
+from astropy.table import Table
+import bokeh
+import urllib.request
+from pathlib import PurePath
+
 
 def read_qa(filename):
     '''
@@ -105,3 +114,214 @@ def get_night_expid(filename):
         return int(hdr['NIGHT']), int(hdr['EXPID'])
 
     raise ValueError('NIGHT and/or EXPID not found in HDU 0 or 1 of {}'.format(filename))
+
+def get_surveyqa_data(infile, name_dict, rawdir, program=True):
+    '''Given surveyqa data file, file of tile data, and dictionary containing equivalent columns, returns
+    two tables of data to feed into surveyqa code.
+    Args:
+        infile: (str) path to file containing surveyqa data
+        name_dict: dictionary with column equivalents
+            Must have equivalents for AIRMASS, SKY, SEEING, TRANSP, RA, DEC, MJD, NIGHT, EXPID.
+        rawdir: directory containing raw data files
+    Options:
+        program: whether or not to use hardcoded information to assign programs to tileids, default=True
+    Returns: two tables, one with aggregated data by exposure, and one with the finer scaled data.'''
+    
+    table = Table.read(infile, hdu=1)
+    
+    new_table = Table()
+    for key in name_dict.keys():
+        new_table[key] = table[name_dict[key]]
+    
+    D = new_table["MJD"] - 51544.5
+    LST = (168.86072948111115 + 360.98564736628623 * D) % 360
+    new_table["HOURANGLE"] = LST - new_table["RA"]
+    
+    def change_range(i):
+        if i > 180:
+            return i - 360
+        if i < -180:
+            return 360 + i
+        return i
+
+    new_table["HOURANGLE"] = [change_range(i) for i in new_table["HOURANGLE"]]
+    
+    table_by_expid = new_table.group_by('EXPID')
+    
+    table_mean = table_by_expid.groups.aggregate(np.nanmean)
+    table_min = table_by_expid.groups.aggregate(np.nanmin)
+
+    exposures = Table()
+    for attr in ["AIRMASS", "SKY", "SEEING", "TRANSP"]:
+        exposures[attr] = table_mean[attr]
+    for attr in ['RA', "DEC", "MJD", "NIGHT", "EXPID", "HOURANGLE"]:
+        exposures[attr] = table_min[attr]
+        
+    flavors = []
+    tiles = []
+    exptimes = []
+
+    for idx in range(len(exposures['EXPID'])):
+
+        night = exposures["NIGHT"][idx]
+        #print(night)
+        expid = exposures['EXPID'][idx]
+        raw_file = os.path.join(rawdir, '{night}/{expid:08d}/desi-{expid:08d}.fits.fz'.format(night=night, expid=expid))
+
+        try:
+            hdul = fits.open(raw_file)
+            header = hdul[1].header
+            hdul.close()
+            try:
+                tiles.append(header['TILEID'])
+            except KeyError:
+                tiles.append(-1)
+            try:
+                flavors.append(header["OBSTYPE"])
+            except KeyError:
+                flavors.append('None')
+            try:
+                exptimes.append(header['EXPTIME'])
+            except:
+                exptimes.append(-1)
+        except:
+            flavors.append('None')
+            exptimes.append(-1)
+            tiles.append(-1)
+
+    exposures["FLAVOR"] = flavors
+    exposures['TILEID'] = tiles
+    exposures['EXPTIME'] = exptimes
+
+    if program:
+        programs = []
+        for row_ in exposures:
+            tileid = row_["TILEID"]
+            if (tileid >= 65000 and tileid < 67000):
+                programs.append('BRIGHT')
+                continue
+            if (tileid >= 67000 and tileid < 68000):
+                programs.append('GRAY')
+                continue
+            if (tileid >= 68000 and tileid < 69000):
+                programs.append("DARK")
+                continue
+            if (tileid >= 70000 and tileid < 70500):
+                programs.append('DARK')
+                continue
+            if (tileid >= 70500 and tileid < 71000):
+                programs.append("BRIGHT")
+                continue
+            if (tileid >= 71000 and tileid < 71100):
+                programs.append("DARK")
+                continue
+            if (tileid >= 72000 and tileid < 72100):
+                programs.append("DARK")
+                continue
+            if (tileid >= 73000 and tileid < 73100):
+                programs.append("GRAY")
+                continue
+            if (tileid >= 74000 and tileid < 74100):
+                programs.append("DARK")
+                continue
+            if (tileid >= 75000 and tileid < 75100):
+                programs.append("BRIGHT")
+                continue
+            if tileid == -1:
+                programs.append('CALIB')
+                continue
+            else:
+                programs.append('OTHER')
+
+        exposures['PROGRAM'] = programs
+    
+    return exposures, table_by_expid
+
+def write_night_linkage(outdir, nights, subset):
+    '''
+    Generates linking.js, which helps in linking all the nightly htmls together
+    Args:
+        outdir : directory to write linking.js and to check for previous html files
+        nights : list of nights (strings) to link together
+        subset : if True : nights is a subset, and we need to include all existing html files in outdir
+                 if False : nights is not a subset, and we do not need to include existing html files in outdir
+    Writes outdir/linking.js, which defines a javascript function
+    `get_linking_json_dict` that returns a dictionary defining the first and
+    last nights, and the previous/next nights for each night.
+    '''
+    f = []
+    f += nights
+    if subset:
+        f_existing = []
+        for (dirpath, dirnames, filenames) in walk(outdir):
+            f.extend(filenames)
+            break
+        regex = re.compile("nightqa-[0-9]+.html")
+        f_existing = [filename for filename in f if regex.match(filename)]
+        f_existing = [i[6:14] for i in f_existing]
+        f += f_existing
+        f = list(dict.fromkeys(f))
+        f.sort()
+    file_js = dict()
+    file_js["first"] = "nightqa-"+str(f[0])+".html"
+    file_js["last"] = "nightqa-"+str(f[len(f)-1])+".html"
+
+    for i in np.arange(len(f)):
+        inner_dict = dict()
+        if (len(f) == 1):
+            inner_dict["prev"] = "none"
+            inner_dict["next"] = "none"
+        elif i == 0:
+            inner_dict["prev"] = "none"
+            inner_dict["next"] = "nightqa-"+str(f[i+1])+".html"
+        elif i == len(f)-1:
+            inner_dict["prev"] = "nightqa-"+str(f[i-1])+".html"
+            inner_dict["next"] = "none"
+        else:
+            inner_dict["prev"] = "nightqa-"+str(f[i-1])+".html"
+            inner_dict["next"] = "nightqa-"+str(f[i+1])+".html"
+        file_js["n"+str(f[i])] = inner_dict
+
+    outfile = os.path.join(outdir, 'linking.js')
+    with open(outfile, 'w') as fp:
+        fp.write("get_linking_json_dict({})".format(json.dumps(file_js)))
+
+    print('Wrote {}'.format(outfile))
+    
+    return file_js
+    
+def check_offline_files(dir):
+    '''
+    Checks if the Bokeh .js and .css files are present (so that the page works offline).
+    If they are not downloaded, they will be fetched and downloaded.
+    Args:
+        dir : directory of where the offline_files folder should be located.
+              If not present, an offline_files folder will be genreated.
+    '''
+    path=(PurePath(dir) / "offline_files")
+    version = bokeh.__version__
+    b_js = (path / 'bokeh-{version}.js'.format(version=version)).as_posix()
+    bt_js = (path / 'bokeh_tables-{version}.js'.format(version=version)).as_posix()
+    b_css = (path / 'bokeh-{version}.css'.format(version=version)).as_posix()
+    bt_css = (path / 'bokeh_tables-{version}.css'.format(version=version)).as_posix()
+
+    if os.path.isfile(b_js) and os.path.isfile(bt_js) and \
+       os.path.isfile(b_css) and os.path.isfile(bt_js):
+        print("Offline Bokeh files found")
+    else:
+        shutil.rmtree(path, True)
+        os.makedirs(path, exist_ok=True)
+
+        url_js = "https://cdn.pydata.org/bokeh/release/bokeh-{version}.min.js".format(version=version)
+        urllib.request.urlretrieve(url_js, b_js)
+
+        url_tables_js = "https://cdn.pydata.org/bokeh/release/bokeh-tables-{version}.min.js".format(version=version)
+        urllib.request.urlretrieve(url_tables_js, bt_js)
+
+        url_css = "https://cdn.pydata.org/bokeh/release/bokeh-{version}.min.css".format(version=version)
+        urllib.request.urlretrieve(url_css, b_css)
+
+        url_tables_css = "https://cdn.pydata.org/bokeh/release/bokeh-tables-{version}.min.css".format(version=version)
+        urllib.request.urlretrieve(url_tables_css, bt_css)
+
+        print("Downloaded offline Bokeh files")

--- a/py/nightwatch/plots/nightlyqa.py
+++ b/py/nightwatch/plots/nightlyqa.py
@@ -1,0 +1,411 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import bokeh as bk
+
+import jinja2
+from bokeh.embed import components
+import bokeh
+import bokeh.plotting as bk
+from bokeh.models import ColumnDataSource
+
+from astropy.time import Time
+from bokeh.models import HoverTool, ColorBar
+from bokeh.layouts import gridplot
+from astropy.table import join
+from astropy.time import TimezoneInfo
+import astropy.units as u
+from datetime import tzinfo
+from datetime import datetime
+from bokeh.models.glyphs import HBar
+from bokeh.models import LabelSet, FactorRange
+from bokeh.palettes import viridis
+from bokeh.transform import factor_cmap
+from bokeh.models.widgets.tables import DataTable, TableColumn
+from astropy import coordinates
+from bokeh.models.widgets import NumberFormatter
+from pathlib import PurePath
+
+import warnings
+warnings.filterwarnings('ignore', 'ERFA function.*dubious year.*')
+warnings.filterwarnings('ignore', 'Tried to get polar motions for times after IERS data is valid.*')
+
+utc_offset = -7*u.hour
+
+def find_night(exposures, night):
+    """
+    Generates a subtable of exposures corresponding to data from a single night N and adds column TIME
+    ARGS:
+        exposures : Table of exposures with columns...
+        night : String representing a single value in the NIGHT column of the EXPOSURES table
+    Returns an astropy table object
+    """
+    #- Filters by NIGHT
+    exposures = exposures[exposures['NIGHT'] == night]
+
+    #- Creates DateTime objects in Arizona timezone
+    mjds = np.array(exposures['MJD'])
+    times = [(Time(mjd, format='mjd', scale='utc') + utc_offset).to_datetime() for mjd in mjds]
+
+    #- Adds times to table
+    exposures['TIME'] = times
+
+    return exposures
+
+
+def get_timeseries(cds, name):
+    """
+    Generates times and values arrays for column `name`
+    ARGS:
+        cds : ColumnDataSource of exposures
+        name : String corresponding to a column in CDS
+    Returns numpy array objects
+    """
+    x = np.array(cds.data['TIME'])
+    y = np.array(cds.data[name])
+
+    return x, y
+
+def plot_timeseries(source, name, color, tools=None, x_range=None, title=None, tooltips=None, width=400, height=150, min_border_left=50, min_border_right=50):
+    """
+    Plots values corresponding to NAME from SOURCE vs. time with TOOLS
+    ARGS:
+        source : ColumnDataSource of exposures
+        name : string name of this timeseries
+        color : color for plotted data points
+        x_range : a range of x values to link multiple plots together
+    Options:
+        height, width: height and width of the graph in pixels
+        x_range: x-axis range of the graph
+        tools: interactive features
+        title: graph title
+        min_border_left, min_border_right: set minimum width of surrounding labels (in pixels)
+    Returns bokeh figure object
+    """
+
+    times, values = get_timeseries(source, name)
+
+    fig = bk.figure(width=width, height=height, tools=tools,
+                    x_axis_type='datetime', x_range=x_range,
+                    active_scroll='wheel_zoom', title=title,
+                    x_axis_label='Time',
+                    min_border_left=min_border_left,
+                    min_border_right=min_border_right)
+    fig.xaxis.axis_label_text_color='#ffffff'
+    fig.line('TIME', name, source=source)
+    r = fig.circle('TIME', name, line_color=color, fill_color='white',
+                   size=6, line_width=2, hover_color='firebrick', source=source)
+
+    #- Formatting
+    fig.xgrid.grid_line_color = None
+    fig.outline_line_color = None
+    fig.yaxis.axis_label = name.title()
+
+    if name == 'TRANSP':
+        fig.yaxis.axis_label = 'Transparency'
+    if name == 'HOURANGLE':
+        fig.yaxis.axis_label = 'Hour Angle'
+    if name == 'EXPTIME':
+        fig.yaxis.axis_label = 'Exposure Time'
+
+    #- Add hover tool
+    hover = HoverTool(renderers = [r], tooltips=tooltips)
+    fig.add_tools(hover)
+
+    return fig
+
+def plot_timeseries_fine(fine_data_src, exposures_src, name, color, tools=None, x_range=None, title=None, tooltips=None, width=400, height=150, min_border_left=50, min_border_right=50):
+    
+#     source = ColumnDataSource(data=dict(
+#         time = fine_data['TIME'],
+#         attr = fine_data[name]
+#     ))
+    
+#     exp_source = ColumnDataSource(data=dict(
+#         time = exposures['TIME'],
+#         med_attr = exposures[name]
+#     ))
+    
+    fig =  bk.figure(plot_height=height, plot_width=width, 
+                     x_range=x_range, x_axis_type='datetime',
+                     active_scroll='wheel_zoom', title=title,
+                     x_axis_label='Time', min_border_left=min_border_left,
+                     min_border_right=min_border_right)
+    fig.circle('TIME', name, size=2, alpha=0.25, color=color, source=fine_data_src)
+    medians = fig.circle('TIME', name, size=8, line_color=color, fill_color='white', 
+                         source=exposures_src, hover_color='firebrick', line_width=2)
+    fig.grid.visible = False
+    
+    fig.yaxis.axis_label = name.title()
+    
+    if name == 'TRANSP':
+        fig.yaxis.axis_label = 'Transparency'
+    if name == 'HOURANGLE':
+        fig.yaxis.axis_label = 'Hour Angle'
+         
+    hover = HoverTool(renderers = [medians], tooltips = tooltips)
+    fig.add_tools(hover)
+    
+    return fig
+    
+
+def get_nightlytable(exposures):
+    '''
+    Generates a summary table of the exposures from the night observed.
+    Args:
+        exposures: Table of exposures with columns...
+    Returns a bokeh DataTable object.
+    '''
+
+    source = ColumnDataSource(data=dict(
+        expid = np.array(exposures['EXPID']),
+        flavor = np.array(exposures['FLAVOR'], dtype='str'),
+        program = np.array(exposures['PROGRAM'], dtype='str'),
+        exptime = np.array(exposures['EXPTIME']),
+        tileid = np.array(exposures['TILEID']),
+        airmass = np.array(exposures['AIRMASS']),
+        seeing = np.array(exposures['SEEING']),
+        transp = np.array(exposures['TRANSP']),
+        sky = np.array(exposures['SKY']),
+        hourangle = np.array(exposures['HOURANGLE'])
+    ))
+
+    formatter = NumberFormatter(format='0,0.00')
+    columns = [
+        TableColumn(field='expid', title='Exposure ID'),
+        TableColumn(field='flavor', title='Flavor'),
+        TableColumn(field='program', title='Program'),
+        TableColumn(field='exptime', title='Exposure Time'),
+        TableColumn(field='tileid', title='Tile ID'),
+        TableColumn(field='airmass', title='Airmass', formatter=formatter),
+        TableColumn(field='seeing', title='Seeing', formatter=formatter),
+        TableColumn(field='transp', title='Transparency', formatter=formatter),
+        TableColumn(field='sky', title='Sky', formatter=formatter),
+        TableColumn(field='hourangle', title='Hour Angle', formatter=formatter)
+    ]
+
+    nightly_table = DataTable(source=source, columns=columns, width=1000, sortable=True)
+
+    return nightly_table
+
+def get_moonloc(night):
+    """
+    Returns the location of the moon on the given NIGHT
+    Args:
+        night : night = YEARMMDD of sunset
+    Returns a SkyCoord object
+    """
+    #- Re-formats night into YYYY-MM-DD HH:MM:SS
+    iso_format = night[:4] + '-' + night[4:6] + '-' + night[6:] + ' 00:00:00'
+    t_midnight = Time(iso_format, format='iso') + 24*u.hour
+    #- Sets timezone
+    t_local = t_midnight + (-7)*u.hour
+
+    #- Sets location
+    kitt = coordinates.EarthLocation.of_site('Kitt Peak National Observatory')
+
+    #- Gets moon coordinates
+    moon_loc = coordinates.get_moon(time=t_local, location=kitt)
+
+    return moon_loc
+
+def get_skypathplot(exposures, tiles, width=600, height=300, min_border_left=50, min_border_right=50):
+    """
+    Generate a plot which maps the location of tiles observed on NIGHT
+    ARGS:
+        exposures : Table of exposures with columns specific to a single night
+        tiles: Table of tile locations with columns ...
+    Options:
+        height, width: height and width of the graph in pixels
+        min_border_left, min_border_right: set minimum width of surrounding labels (in pixels)
+    Returns a bokeh figure object
+    """
+    #- Merges tiles data for all exposures on a single night N
+    tiles_and_exps = join(exposures, tiles['STAR_DENSITY', 'EXPOSEFAC', 'OBSCONDITIONS', 'TILEID'], keys='TILEID')
+    tiles_and_exps.sort('TIME')
+
+    #- Converts data format into ColumnDataSource
+    src = ColumnDataSource(data={'RA':np.array(tiles_and_exps['RA']),
+                                 'DEC':np.array(tiles_and_exps['DEC']),
+                                 'EXPID':np.array(tiles_and_exps['EXPID']),
+                                 'PROGRAM':np.array([str(n) for n in tiles_and_exps['PROGRAM']])})
+
+    #- Plot options
+    night_name = exposures['NIGHT'][0]
+    string_date = night_name[4:6] + "-" + night_name[6:] + "-" + night_name[:4]
+
+    fig = bk.figure(width=width, height=height, title='Tiles observed on ' + string_date,
+                    min_border_left=min_border_left, min_border_right=min_border_right)
+    fig.yaxis.axis_label = 'Declination (degrees)'
+    fig.xaxis.axis_label = 'Right Ascension (degrees)'
+
+    #- Plots all tiles
+    unobs = fig.circle(tiles['RA'], tiles['DEC'], color='gray', size=1)
+
+    #- Color-coding for program
+    EXPTYPES = ['DARK', 'GRAY', 'BRIGHT']
+    COLORS = ['red', 'blue', 'green']
+    mapper = factor_cmap(field_name='PROGRAM', palette=COLORS, factors=EXPTYPES)
+
+    #- Plots tiles observed on NIGHT
+    obs = fig.scatter('RA', 'DEC', size=5, fill_alpha=0.7, legend='PROGRAM', source=src, color=mapper)
+    fig.line(src.data['RA'], src.data['DEC'], color='navy', alpha=0.4)
+
+    #- Stars the first point observed on NIGHT
+    first = tiles_and_exps[0]
+    fig.asterisk(first['RA'], first['DEC'], size=10, line_width=1.5, fill_color=None, color='orange')
+
+    #- Adds moon location at midnight on NIGHT
+    night = exposures['NIGHT'][0]
+    moon_loc = get_moonloc(night)
+    ra, dec = float(moon_loc.ra.to_string(decimal=True)), float(moon_loc.dec.to_string(decimal=True))
+    fig.circle(ra, dec, size=10, color='gold')
+
+
+    #- Circles the first point observed on NIGHT
+    first = tiles_and_exps[0]
+    fig.asterisk(first['RA'], first['DEC'], size=10, line_width=1.5, fill_color=None, color='gold')
+
+    #- Adds hover tool
+    TOOLTIPS = [("(RA, DEC)", "(@RA, @DEC)"), ("EXPID", "@EXPID")]
+    obs_hover = HoverTool(renderers = [obs], tooltips=TOOLTIPS)
+    fig.add_tools(obs_hover)
+
+    return fig
+
+def overlaid_hist(all_exposures, night_exposures, attribute, color, width=300, height=150, min_border_left=50, min_border_right=50):
+    """
+    Generates an overlaid histogram for a single attribute comparing the distribution
+    for all of the exposures vs. those from just one night
+    ARGS:
+        all_exposures : a table of all the science exposures
+        night_exposures : a table of all the science exposures for a single night
+        attribute : a string name of a column in the exposures tables
+        color : color of histogram
+    Options:
+        height, width: height and width of the graph in pixels
+        min_border_left, min_border_right: set minimum width of surrounding labels (in pixels)
+    Returns a bokeh figure object
+    """
+    all_attr = np.array(all_exposures[attribute])
+    night_attr = np.array(night_exposures[attribute])
+    
+    all_attr = all_attr[~np.isnan(all_attr)]
+    night_attr = night_attr[~np.isnan(night_attr)]
+    
+    hist_all, edges_all = np.histogram(all_attr, density=True, bins=25)
+    hist_night, edges_night = np.histogram(night_attr, density=True, bins=25)
+
+    fig = bk.figure(plot_width=width, plot_height=height,
+                    x_axis_label = attribute.title(), y_axis_label = 'title',
+                    min_border_left=min_border_left, min_border_right=min_border_right)
+    fig.quad(top=hist_all, bottom=0, left=edges_all[:-1], right=edges_all[1:], fill_color=color, alpha=0.2)
+    fig.quad(top=hist_night, bottom=0, left=edges_night[:-1], right=edges_night[1:], fill_color=color, alpha=0.6)
+
+    if attribute == 'TRANSP':
+        fig.xaxis.axis_label = 'Transparency'
+    if attribute == 'HOURANGLE':
+        fig.xaxis.axis_label = 'Hour Angle'
+    if attribute == 'EXPTIME':
+        fig.xaxis.axis_label = 'Exposure Time'
+
+    fig.yaxis.major_label_text_font_size = '0pt'
+    fig.yaxis.major_tick_line_color = None
+    fig.yaxis.minor_tick_line_color = None
+    fig.yaxis.axis_label_text_color = '#ffffff'
+    fig.ygrid.grid_line_color = None
+    fig.xgrid.grid_line_color = None
+    fig.toolbar_location = None
+
+    return fig
+
+def overlaid_hist_fine(all_data, night_data, attribute, color, width=300, height=150, min_border_left=50, min_border_right=50):
+    """
+    Generates an overlaid histogram for a single attribute comparing the distribution
+    for all of the exposures vs. those from just one night
+    ARGS:
+        all_data : a table of all the exposures + finer data
+        night_data : a table of all the exposures + finer data for a single night
+        attribute : a string name of a column in the exposures tables
+        color : color of histogram
+    Options:
+        height, width: height and width of the graph in pixels
+        min_border_left, min_border_right: set minimum width of surrounding labels (in pixels)
+    Returns a bokeh figure object
+    """
+    all_attr = np.array(all_data[attribute])
+    night_attr = np.array(night_data[attribute])
+    
+    all_attr = all_attr[~np.isnan(all_attr)]
+    night_attr = night_attr[~np.isnan(night_attr)]
+    
+    hist_all, edges_all = np.histogram(all_attr, density=True, bins=25)
+    hist_night, edges_night = np.histogram(night_attr, density=True, bins=25)
+
+    fig = bk.figure(plot_width=width, plot_height=height,
+                    x_axis_label = attribute.title(), y_axis_label = 'title',
+                    min_border_left=min_border_left, min_border_right=min_border_right)
+    fig.quad(top=hist_all, bottom=0, left=edges_all[:-1], right=edges_all[1:], fill_color=color, alpha=0.2)
+    fig.quad(top=hist_night, bottom=0, left=edges_night[:-1], right=edges_night[1:], fill_color=color, alpha=0.6)
+
+    if attribute == 'TRANSP':
+        fig.xaxis.axis_label = 'Transparency'
+    if attribute == 'HOURANGLE':
+        fig.xaxis.axis_label = 'Hour Angle'
+    if attribute == 'EXPTIME':
+        fig.xaxis.axis_label = 'Exposure Time'
+
+    fig.yaxis.major_label_text_font_size = '0pt'
+    fig.yaxis.major_tick_line_color = None
+    fig.yaxis.minor_tick_line_color = None
+    fig.yaxis.axis_label_text_color = '#ffffff'
+    fig.ygrid.grid_line_color = None
+    fig.xgrid.grid_line_color = None
+    fig.toolbar_location = None
+
+    return fig
+
+def get_exptype_counts(exposures, calibs, width=300, height=300, min_border_left=50, min_border_right=50):
+    """
+    Generate a horizontal bar plot showing the counts for each type of
+    exposure grouped by whether they have FLAVOR='science' or PROGRAM='calib'
+    ARGS:
+        exposures : a table of exposures which only contain those with FLAVOR='science'
+        calibs : a table of exposures which only contains those with PROGRAm='calibs'
+    Options:
+        height, width: height and width in pixels
+        min_border_left, min_border_right = set minimum width of surrounding labels (in pixels)
+    """
+    darks = len(exposures[exposures['PROGRAM'] == 'DARK'])
+    grays = len(exposures[exposures['PROGRAM'] == 'GRAY'])
+    brights = len(exposures[exposures['PROGRAM'] == 'BRIGHT'])
+
+    arcs = len(calibs['arc' in calibs['FLAVOR']])
+    flats = len(calibs['flat' in calibs['FLAVOR']])
+    zeroes = len(calibs['zero' in calibs['FLAVOR']])
+
+    types = [('calib', 'ZERO'), ('calib', 'FLAT'), ('calib', 'ARC'),
+            ('science', 'BRIGHT'), ('science', 'GRAY'), ('science', 'DARK')]
+    counts = np.array([zeroes, flats, arcs, brights, grays, darks])
+    COLORS = ['tan', 'orange', 'yellow', 'green', 'blue', 'red']
+
+    src = ColumnDataSource({'types':types, 'counts':counts})
+
+    p = bk.figure(width=width, height=height,
+                   x_range=(0, np.max(counts)*1.15),
+                  y_range=FactorRange(*types), title='Exposure Type Counts',
+                  toolbar_location=None, min_border_left=min_border_left, min_border_right=min_border_right)
+    p.hbar(y='types', right='counts', left=0, height=0.5, line_color='white',
+           fill_color=factor_cmap('types', palette=COLORS, factors=types), source=src)
+
+
+    labels = LabelSet(x='counts', y='types', text='counts', level='glyph', source=src,
+                      render_mode='canvas', x_offset=5, y_offset=-7,
+                      text_color='gray', text_font='tahoma', text_font_size='8pt')
+    p.add_layout(labels)
+
+    p.ygrid.grid_line_color=None
+    p.xaxis.axis_label = 'label'
+    p.xaxis.axis_label_text_color = '#ffffff'
+
+    return p

--- a/py/nightwatch/plots/nightlyqa.py
+++ b/py/nightwatch/plots/nightlyqa.py
@@ -80,9 +80,12 @@ def plot_timeseries(source, name, color, tools=None, x_range=None, y_range=None,
     Options:
         height, width: height and width of the graph in pixels
         x_range: x-axis range of the graph
+        y_range : a range of y values for the plot
         tools: interactive features
         title: graph title
         min_border_left, min_border_right: set minimum width of surrounding labels (in pixels)
+        tools : list of bokeh tools for the toolbar
+        tooltips : a bokeh tooltip object for the plot hover
     Returns bokeh figure object
     """
 
@@ -118,6 +121,25 @@ def plot_timeseries(source, name, color, tools=None, x_range=None, y_range=None,
     return fig
 
 def plot_timeseries_fine(fine_data_src, exposures_src, name, color, tools=None, x_range=None, y_range=None, title=None, tooltips=None, width=400, height=150, min_border_left=50, min_border_right=50):
+    """
+    Plots values corresponding to NAME from SOURCE vs. time with TOOLS. Both per-exposure and finer-scaled data are plotted.
+    ARGS:
+        fine_data_src : ColumnDataSource of gfa_reduce level data
+        exposures_src : ColumnDataSource of per-exposure level data
+        name : string name of this timeseries
+        color : color for plotted data points
+        x_range : a range of x values to link multiple plots together
+    Options:
+        height, width: height and width of the graph in pixels
+        x_range: x-axis range of the graph
+        y_range : a range of y values for the plot
+        tools: interactive features
+        title: graph title
+        min_border_left, min_border_right: set minimum width of surrounding labels (in pixels)
+        tools : list of bokeh tools for the toolbar
+        tooltips : a bokeh tooltip object for the plot hover
+    Returns bokeh figure object
+    """
     
 #     source = ColumnDataSource(data=dict(
 #         time = fine_data['TIME'],
@@ -217,11 +239,13 @@ def get_skypathplot(src, tiles, night, width=600, height=300, tools=None, toolti
     """
     Generate a plot which maps the location of tiles observed on NIGHT
     ARGS:
-        exposures : Table of exposures with columns specific to a single night
+        src : ColumnDataSource of exposures with columns specific to a single night
         tiles: Table of tile locations with columns ...
         night: int
     Options:
         height, width: height and width of the graph in pixels
+        tools : list of bokeh tools for plot
+        tooltips : Bokeh tooltips object to configure hover tool
         min_border_left, min_border_right: set minimum width of surrounding labels (in pixels)
     Returns a bokeh figure object
     """
@@ -284,10 +308,10 @@ def overlaid_hist(all_exposures, night_exposures, attribute, color, width=300, h
         night_exposures : a table of all the science exposures for a single night
         attribute : a string name of a column in the exposures tables
         color : color of histogram
-        hist_range : (min, max) to clip values.
     Options:
         height, width: height and width of the graph in pixels
         min_border_left, min_border_right: set minimum width of surrounding labels (in pixels)
+        hist_min, hist_max : min, max to clip values (int). Default is None for both.
     Returns a bokeh figure object
     """
     all_attr = np.array(all_exposures[attribute])
@@ -338,6 +362,7 @@ def overlaid_hist_fine(all_data, night_data, attribute, color, width=300, height
     Options:
         height, width: height and width of the graph in pixels
         min_border_left, min_border_right: set minimum width of surrounding labels (in pixels)
+        hist_min, hist_max : min, max to clip values (int). Default is None for both.
     Returns a bokeh figure object
     """
     all_attr = np.array(all_data[attribute])

--- a/py/nightwatch/plots/nightlyqa.py
+++ b/py/nightwatch/plots/nightlyqa.py
@@ -66,7 +66,7 @@ def get_timeseries(cds, name):
 
     return x, y
 
-def plot_timeseries(source, name, color, tools=None, x_range=None, title=None, tooltips=None, width=400, height=150, min_border_left=50, min_border_right=50):
+def plot_timeseries(source, name, color, tools=None, x_range=None, y_range=None, title=None, tooltips=None, width=400, height=150, min_border_left=50, min_border_right=50):
     """
     Plots values corresponding to NAME from SOURCE vs. time with TOOLS
     ARGS:
@@ -87,8 +87,8 @@ def plot_timeseries(source, name, color, tools=None, x_range=None, title=None, t
 
     fig = bk.figure(width=width, height=height, tools=tools,
                     x_axis_type='datetime', x_range=x_range,
-                    active_scroll='wheel_zoom', title=title,
-                    x_axis_label='Time', output_backend="webgl",
+                    y_range=y_range, active_scroll='wheel_zoom', 
+                    title=title, x_axis_label='Time', output_backend="webgl",
                     min_border_left=min_border_left,
                     min_border_right=min_border_right)
     fig.xaxis.axis_label_text_color='#ffffff'
@@ -114,7 +114,7 @@ def plot_timeseries(source, name, color, tools=None, x_range=None, title=None, t
 
     return fig
 
-def plot_timeseries_fine(fine_data_src, exposures_src, name, color, tools=None, x_range=None, title=None, tooltips=None, width=400, height=150, min_border_left=50, min_border_right=50):
+def plot_timeseries_fine(fine_data_src, exposures_src, name, color, tools=None, x_range=None, y_range=None, title=None, tooltips=None, width=400, height=150, min_border_left=50, min_border_right=50):
     
 #     source = ColumnDataSource(data=dict(
 #         time = fine_data['TIME'],
@@ -127,7 +127,7 @@ def plot_timeseries_fine(fine_data_src, exposures_src, name, color, tools=None, 
 #     ))
     
     fig =  bk.figure(plot_height=height, plot_width=width, 
-                     x_range=x_range, x_axis_type='datetime',
+                     x_range=x_range, y_range=y_range, x_axis_type='datetime',
                      active_scroll='wheel_zoom', title=title,
                      x_axis_label='Time', min_border_left=min_border_left,
                      min_border_right=min_border_right, output_backend="webgl",
@@ -272,7 +272,7 @@ def get_skypathplot(src, tiles, night, width=600, height=300, tools=None, toolti
 
     return fig
 
-def overlaid_hist(all_exposures, night_exposures, attribute, color, width=300, height=150, min_border_left=50, min_border_right=50):
+def overlaid_hist(all_exposures, night_exposures, attribute, color, width=300, height=150, min_border_left=50, min_border_right=50, hist_min=None, hist_max=None):
     """
     Generates an overlaid histogram for a single attribute comparing the distribution
     for all of the exposures vs. those from just one night
@@ -281,6 +281,7 @@ def overlaid_hist(all_exposures, night_exposures, attribute, color, width=300, h
         night_exposures : a table of all the science exposures for a single night
         attribute : a string name of a column in the exposures tables
         color : color of histogram
+        hist_range : (min, max) to clip values.
     Options:
         height, width: height and width of the graph in pixels
         min_border_left, min_border_right: set minimum width of surrounding labels (in pixels)
@@ -291,6 +292,10 @@ def overlaid_hist(all_exposures, night_exposures, attribute, color, width=300, h
     
     all_attr = all_attr[~np.isnan(all_attr)]
     night_attr = night_attr[~np.isnan(night_attr)]
+    
+    if (hist_min is not None and hist_max is not None):
+        all_attr = np.clip(all_attr, hist_min, hist_max)
+        night_attr = np.clip(night_attr, hist_min, hist_max)
     
     hist_all, edges_all = np.histogram(all_attr, density=True, bins=25)
     hist_night, edges_night = np.histogram(night_attr, density=True, bins=25)
@@ -318,7 +323,7 @@ def overlaid_hist(all_exposures, night_exposures, attribute, color, width=300, h
 
     return fig
 
-def overlaid_hist_fine(all_data, night_data, attribute, color, width=300, height=150, min_border_left=50, min_border_right=50):
+def overlaid_hist_fine(all_data, night_data, attribute, color, width=300, height=150, min_border_left=50, min_border_right=50, hist_min=None, hist_max=None):
     """
     Generates an overlaid histogram for a single attribute comparing the distribution
     for all of the exposures vs. those from just one night
@@ -337,6 +342,10 @@ def overlaid_hist_fine(all_data, night_data, attribute, color, width=300, height
     
     all_attr = all_attr[~np.isnan(all_attr)]
     night_attr = night_attr[~np.isnan(night_attr)]
+    
+    if (hist_min is not None and hist_max is not None):
+        all_attr = np.clip(all_attr, hist_min, hist_max)
+        night_attr = np.clip(night_attr, hist_min, hist_max)
     
     hist_all, edges_all = np.histogram(all_attr, density=True, bins=25)
     hist_night, edges_night = np.histogram(night_attr, density=True, bins=25)

--- a/py/nightwatch/plots/nightlyqa.py
+++ b/py/nightwatch/plots/nightlyqa.py
@@ -134,8 +134,10 @@ def plot_timeseries_fine(fine_data_src, exposures_src, name, color, tools=None, 
     fig.circle('TIME', name, size=2, alpha=0.25, color=color, source=fine_data_src)
     medians = fig.circle('TIME', name, size=8, line_color=color, fill_color='white', 
                          source=exposures_src, hover_color='firebrick', line_width=2)
-    fig.grid.visible = False
     
+    #formatting
+    fig.xgrid.grid_line_color = None
+    fig.outline_line_color = None
     fig.yaxis.axis_label = name.title()
     
     if name == 'TRANSP':

--- a/py/nightwatch/plots/nightlyqa.py
+++ b/py/nightwatch/plots/nightlyqa.py
@@ -88,7 +88,7 @@ def plot_timeseries(source, name, color, tools=None, x_range=None, title=None, t
     fig = bk.figure(width=width, height=height, tools=tools,
                     x_axis_type='datetime', x_range=x_range,
                     active_scroll='wheel_zoom', title=title,
-                    x_axis_label='Time',
+                    x_axis_label='Time', output_backend="webgl",
                     min_border_left=min_border_left,
                     min_border_right=min_border_right)
     fig.xaxis.axis_label_text_color='#ffffff'
@@ -130,7 +130,7 @@ def plot_timeseries_fine(fine_data_src, exposures_src, name, color, tools=None, 
                      x_range=x_range, x_axis_type='datetime',
                      active_scroll='wheel_zoom', title=title,
                      x_axis_label='Time', min_border_left=min_border_left,
-                     min_border_right=min_border_right)
+                     min_border_right=min_border_right, output_backend="webgl")
     fig.circle('TIME', name, size=2, alpha=0.25, color=color, source=fine_data_src)
     medians = fig.circle('TIME', name, size=8, line_color=color, fill_color='white', 
                          source=exposures_src, hover_color='firebrick', line_width=2)

--- a/py/nightwatch/plots/nightlyqa.py
+++ b/py/nightwatch/plots/nightlyqa.py
@@ -30,6 +30,9 @@ import warnings
 warnings.filterwarnings('ignore', 'ERFA function.*dubious year.*')
 warnings.filterwarnings('ignore', 'Tried to get polar motions for times after IERS data is valid.*')
 
+from bokeh.core.validation.warnings import MISSING_RENDERERS
+warnings_set = bokeh.core.validation.silence(MISSING_RENDERERS, True)
+
 utc_offset = -7*u.hour
 
 def find_night(exposures, night):

--- a/py/nightwatch/plots/nightlyqa.py
+++ b/py/nightwatch/plots/nightlyqa.py
@@ -130,7 +130,8 @@ def plot_timeseries_fine(fine_data_src, exposures_src, name, color, tools=None, 
                      x_range=x_range, x_axis_type='datetime',
                      active_scroll='wheel_zoom', title=title,
                      x_axis_label='Time', min_border_left=min_border_left,
-                     min_border_right=min_border_right, output_backend="webgl")
+                     min_border_right=min_border_right, output_backend="webgl",
+                     tools=tools)
     fig.circle('TIME', name, size=2, alpha=0.25, color=color, source=fine_data_src)
     medians = fig.circle('TIME', name, size=8, line_color=color, fill_color='white', 
                          source=exposures_src, hover_color='firebrick', line_width=2)
@@ -209,7 +210,7 @@ def get_moonloc(night):
 
     return moon_loc
 
-def get_skypathplot(exposures, tiles, night, width=600, height=300, min_border_left=50, min_border_right=50):
+def get_skypathplot(src, tiles, night, width=600, height=300, tools=None, tooltips=None, min_border_left=50, min_border_right=50):
     """
     Generate a plot which maps the location of tiles observed on NIGHT
     ARGS:
@@ -222,16 +223,19 @@ def get_skypathplot(exposures, tiles, night, width=600, height=300, min_border_l
     Returns a bokeh figure object
     """
     #- Converts data format into ColumnDataSource
-    src = ColumnDataSource(data={'RA':np.array(exposures['RA']),
-                                 'DEC':np.array(exposures['DEC']),
-                                 'EXPID':np.array(exposures['EXPID']),
-                                 'PROGRAM':np.array([str(n) for n in exposures['PROGRAM']])})
+#     src = ColumnDataSource(data={'RA':np.array(exposures['RA']),
+#                                  'DEC':np.array(exposures['DEC']),
+#                                  'EXPID':np.array(exposures['EXPID']),
+#                                  'PROGRAM':np.array([str(n) for n in exposures['PROGRAM']]),
+#                                  'TILEID':np.array(exposures['TILEID']),
+#                                 })
 
     #- Plot options
     string_date = str(night)[4:6] + "-" + str(night)[6:] + "-" + str(night)[:4]
 
     fig = bk.figure(width=width, height=height, title='Tiles observed on ' + string_date,
-                    min_border_left=min_border_left, min_border_right=min_border_right)
+                    min_border_left=min_border_left, min_border_right=min_border_right,
+                   tools=tools)
     fig.yaxis.axis_label = 'Declination (degrees)'
     fig.xaxis.axis_label = 'Right Ascension (degrees)'
 
@@ -239,7 +243,7 @@ def get_skypathplot(exposures, tiles, night, width=600, height=300, min_border_l
     unobs = fig.circle(tiles['RA'], tiles['DEC'], color='gray', size=1, alpha=0.1)
 
     #- Plots tiles observed on NIGHT
-    obs = fig.scatter('RA', 'DEC', size=5, fill_alpha=0.7, source=src)
+    obs = fig.scatter('RA', 'DEC', size=5, fill_alpha=0.7, source=src, hover_color='firebrick')
     fig.line(src.data['RA'], src.data['DEC'], color='navy', alpha=0.4)
 
     #- Stars the first point observed on NIGHT
@@ -248,7 +252,7 @@ def get_skypathplot(exposures, tiles, night, width=600, height=300, min_border_l
         dec = src.data['DEC']
         fig.asterisk(ra[0], dec[0], size=10, line_width=1.5, fill_color=None, color='orange')
     except:
-        print('No data for {night}'.format(night=night))
+        print('Cannot find first exposure for {night}'.format(night=night))
 
     #- Adds moon location at midnight on NIGHT
 #     night = str(exposures['NIGHT'][0])
@@ -262,7 +266,7 @@ def get_skypathplot(exposures, tiles, night, width=600, height=300, min_border_l
 #     fig.asterisk(first['RA'], first['DEC'], size=10, line_width=1.5, fill_color=None, color='gold')
 
     #- Adds hover tool
-    TOOLTIPS = [("(RA, DEC)", "(@RA, @DEC)"), ("EXPID", "@EXPID")]
+    TOOLTIPS = [("(RA, DEC)", "(@RA, @DEC)"), ("EXPID", "@EXPID"), ("TILEID", "@TILEID")]
     obs_hover = HoverTool(renderers = [obs], tooltips=TOOLTIPS)
     fig.add_tools(obs_hover)
 

--- a/py/nightwatch/plots/summaryqa.py
+++ b/py/nightwatch/plots/summaryqa.py
@@ -58,7 +58,8 @@ def get_skyplot(exposures, tiles, width=500, height=250, min_border_left=50, min
     color_mapper = LinearColorMapper(palette="Viridis256", low=exposures_sorted['MJD'].min(), high=exposures_sorted['MJD'].max())
 
     #making figure
-    fig = bk.figure(width=width, height=height, min_border_left=min_border_left, min_border_right=min_border_right)
+    fig = bk.figure(width=width, height=height, min_border_left=min_border_left, 
+                    min_border_right=min_border_right, output_backend="webgl")
 
     #observed tiles
     tile_renderer = fig.circle('RA', "DEC", color='gray', size=1, alpha=0.1, source=tiles_source)

--- a/py/nightwatch/plots/summaryqa.py
+++ b/py/nightwatch/plots/summaryqa.py
@@ -120,9 +120,8 @@ def get_summarytable(exposures):
         exposures: Table of exposures with columns...
     Returns a bokeh DataTable object.
     '''
-    #exposures_reversed = exposures.reverse()
     
-    nights = np.unique(exposures['NIGHT'])
+    nights = np.unique(exposures['NIGHT'])[::-1]
 
 #     isbright = (exposures['PROGRAM'] == 'BRIGHT')
 #     isgray = (exposures['PROGRAM'] == 'GRAY')
@@ -175,11 +174,11 @@ def get_summarytable(exposures):
         TableColumn(field='med_air', title='Median Airmass', width=100, formatter=formatter),
         TableColumn(field='med_seeing', title='Median Seeing', width=100, formatter=formatter),
         TableColumn(field='med_sky', title='Median Sky', width=100, formatter=formatter),
-        TableColumn(field='med_transp', title='Median Transparency', width=115, formatter=formatter),
-        TableColumn(field='med_angle', title='Median Hour Angle', width=115, formatter=formatter),
+        TableColumn(field='med_transp', title='Median Transparency', width=125, formatter=formatter),
+        TableColumn(field='med_angle', title='Median Hour Angle', width=125, formatter=formatter),
     ]
 
-    summary_table = DataTable(source=source, columns=columns, width=750, sortable=True, fit_columns=False)
+    summary_table = DataTable(source=source, columns=columns, width=850, sortable=True, fit_columns=True)
     return summary_table
 
 def get_hist(fine_data, attribute, color, width=250, height=250, min_border_left=50, min_border_right=50):

--- a/py/nightwatch/plots/summaryqa.py
+++ b/py/nightwatch/plots/summaryqa.py
@@ -100,8 +100,9 @@ def get_skyplot(exposures, tiles, width=500, height=250, min_border_left=50, min
 def get_median(attribute, exposures, nights):
     '''Get the median value for a given attribute for all nights for all exposures taken each night.
     Input:
-        attributes: one of the labels in the exposure column, string
+        attribute: one of the labels in the exposure column, string
         exposures: table with the exposures data
+        nights: list of nights to retrieve medians for
     Output:
         returns a numpy array of the median values for each night
     '''

--- a/py/nightwatch/plots/summaryqa.py
+++ b/py/nightwatch/plots/summaryqa.py
@@ -1,0 +1,257 @@
+import numpy as np
+import scipy as sp
+
+import bokeh
+import bokeh.plotting as bk
+from bokeh.models import LinearColorMapper, ColorBar, ColumnDataSource, HTMLTemplateFormatter, NumeralTickFormatter, OpenURL, TapTool, HoverTool, Label, FactorRange, Div, CustomJS, Slider, Image, Legend, Span
+from bokeh.transform import cumsum, transform
+from bokeh.layouts import column, gridplot, row
+from bokeh.colors import RGB
+from bokeh.models.widgets import NumberFormatter
+from bokeh.models.widgets.tables import DataTable, TableColumn
+
+import astropy
+from astropy.table import Table, join
+from astropy.io import fits as fits
+from astropy.time import Time, TimezoneInfo
+from datetime import datetime, tzinfo, timedelta
+import astropy.units as u
+from collections import Counter, OrderedDict
+from pathlib import PurePath
+
+#- Avoid warnings from date & coord calculations in the future
+import warnings
+warnings.filterwarnings('ignore', 'ERFA function.*dubious year.*')
+warnings.filterwarnings('ignore', 'Tried to get polar motions for times after IERS data is valid.*')
+
+def get_skyplot(exposures, tiles, width=500, height=250, min_border_left=50, min_border_right=50):
+    '''
+    Generates sky plot of DESI survey tiles and progress. Colorcoded by night each tile was first
+    observed, uses nights_first_observed function defined previously in this module to retrieve
+    night each tile was first observed.
+    Args:
+        exposures: Table of exposures with columns ...
+        tiles: Table of tile locations with columns ...
+    Options:
+        width, height: plot width and height in pixels
+        min_border_left, min_border_right: set minimum width for external labels in pixels
+    Returns bokeh Figure object
+    '''
+
+    exposures_sorted = Table(np.sort(exposures, order='MJD'))
+    tiles_sorted = Table(np.sort(tiles, order='TILEID'))
+    
+    source = ColumnDataSource(data=dict(
+        RA = exposures_sorted['RA'],
+        DEC = exposures_sorted['DEC'],
+        NIGHT = exposures_sorted['NIGHT'],
+        MJD = exposures_sorted['MJD'],
+        EXPID = exposures_sorted['EXPID'],
+    ))
+    
+    tiles_source = ColumnDataSource(data=dict(
+        RA = tiles_sorted['RA'],
+        DEC = tiles_sorted['DEC'],
+        TILEID = tiles_sorted['TILEID']
+    ))
+
+    color_mapper = LinearColorMapper(palette="Viridis256", low=exposures_sorted['MJD'].min(), high=exposures_sorted['MJD'].max())
+
+    #making figure
+    fig = bk.figure(width=width, height=height, min_border_left=min_border_left, min_border_right=min_border_right)
+
+    #observed tiles
+    tile_renderer = fig.circle('RA', "DEC", color='gray', size=1, alpha=0.1, source=tiles_source)
+    renderer = fig.circle('RA', 'DEC', color=transform('MJD', color_mapper), size=7, alpha=0.5, source=source)
+    #fig.line('RA', 'DEC', line_width=1, line_color='black', line_dash='dashed', alpha=0.5, source=source)
+    color_bar = ColorBar(color_mapper=color_mapper, label_standoff=12, location=(0,0), title='MJD', width=5)
+    fig.add_layout(color_bar, 'right')
+
+    fig.xaxis.axis_label = 'RA [degrees]'
+    fig.yaxis.axis_label = 'Declination [degrees]'
+    fig.title.text = 'Observed Tiles, Nightly Progress'
+    fig.grid.visible = False
+    
+    hover = HoverTool(
+            tooltips="""
+                <font face="Arial" size="0">
+                <font color="blue"> RA: </font> @RA <br>
+                <font color="blue"> DEC: </font> @DEC <br>
+                <font color="blue"> NIGHT/EXPID: </font> @NIGHT / @EXPID
+                </font>
+            """, renderers = [renderer]
+        )
+    
+#     tile_hover = HoverTool(
+#             tooltips="""
+#                 <font face="Arial" size="0">
+#                 <font color="blue"> RA: </font> @RA <br>
+#                 <font color="blue"> DEC: </font> @DEC <br>
+#                 <font color="blue"> TILEID: </font> @TILEID
+#                 </font>
+#             """, renderers = [tile_renderer]
+#         )
+
+    fig.add_tools(hover)
+
+    return fig
+
+def get_median(attribute, exposures):
+    '''Get the median value for a given attribute for all nights for all exposures taken each night.
+    Input:
+        attributes: one of the labels in the exposure column, string
+        exposures: table with the exposures data
+    Output:
+        returns a numpy array of the median values for each night
+    '''
+    medians = []
+    for n in np.unique(exposures['NIGHT']):
+        ii = (exposures['NIGHT'] == n)
+        attrib = np.asarray(exposures[attribute])[ii]
+        medians.append(np.ma.median(attrib))  #- use masked median
+
+    return np.array(medians)
+
+def get_summarytable(exposures):
+    '''
+    Generates a summary table of key values for each night observed. Uses collections.Counter(), OrderedDict()
+    Args:
+        exposures: Table of exposures with columns...
+    Returns a bokeh DataTable object.
+    '''
+    nights = np.unique(exposures['NIGHT'])
+
+    isbright = (exposures['PROGRAM'] == 'BRIGHT')
+    isgray = (exposures['PROGRAM'] == 'GRAY')
+    isdark = (exposures['PROGRAM'] == 'DARK')
+    iscalib = (exposures['PROGRAM'] == 'CALIB')
+
+    num_nights = len(nights)
+    brights = list()
+    grays = list()
+    darks = list()
+    calibs = list()
+    totals = list()
+    for n in nights:
+        thisnight = exposures['NIGHT'] == n
+        totals.append(np.count_nonzero(thisnight))
+        brights.append(np.count_nonzero(thisnight & isbright))
+        grays.append(np.count_nonzero(thisnight & isgray))
+        darks.append(np.count_nonzero(thisnight & isdark))
+        calibs.append(np.count_nonzero(thisnight & iscalib))
+
+    med_air = get_median('AIRMASS', exposures)
+    med_seeing = get_median('SEEING', exposures)
+    med_exptime = get_median('EXPTIME', exposures)
+    med_transp = get_median('TRANSP', exposures)
+    med_sky = get_median('SKY', exposures)
+    med_angle = get_median('HOURANGLE', exposures)
+
+    source = ColumnDataSource(data=dict(
+        nights = list(nights),
+        totals = totals,
+        brights = brights,
+        grays = grays,
+        darks = darks,
+        calibs = calibs,
+        med_air = med_air,
+        med_seeing = med_seeing,
+        med_exptime = med_exptime,
+        med_transp = med_transp,
+        med_sky = med_sky,
+        med_angle = med_angle,
+    ))
+
+    formatter = NumberFormatter(format='0,0.00')
+    template_str = '<a href="nightqa-<%= nights %>.html"' + ' target="_blank"><%= value%></a>'
+
+    columns = [
+        TableColumn(field='nights', title='NIGHT', width=100, formatter=HTMLTemplateFormatter(template=template_str)),
+        TableColumn(field='totals', title='Total', width=50),
+        TableColumn(field='brights', title='Bright', width=50),
+        TableColumn(field='grays', title='Gray', width=50),
+        TableColumn(field='darks', title='Dark', width=50),
+        TableColumn(field='calibs', title='Calibs', width=50),
+        TableColumn(field='med_exptime', title='Median Exp. Time', width=100),
+        TableColumn(field='med_air', title='Median Airmass', width=100, formatter=formatter),
+        TableColumn(field='med_seeing', title='Median Seeing', width=100, formatter=formatter),
+        TableColumn(field='med_sky', title='Median Sky', width=100, formatter=formatter),
+        TableColumn(field='med_transp', title='Median Transparency', width=115, formatter=formatter),
+        TableColumn(field='med_angle', title='Median Hour Angle', width=115, formatter=formatter),
+    ]
+
+    summary_table = DataTable(source=source, columns=columns, width=900, sortable=True, fit_columns=False)
+    return summary_table
+
+def get_hist(fine_data, attribute, color, width=250, height=250, min_border_left=50, min_border_right=50):
+    '''
+    Generates a histogram of the attribute provided for the given exposures table
+    Args:
+        exposures: Table of exposures with columns "PROGRAM" and attribute
+        attribute: String; must be the label of a column in exposures
+        color: String; color of the histogram
+    Options:
+        width, height: plot width and height in pixels
+        min_border_left, min_border_right: set minimum width for external labels in pixels
+    Returns bokeh Figure object
+    '''
+    #keep = exposures['PROGRAM'] != 'CALIB'
+    #exposures_nocalib = exposures[keep]
+    
+    attr_data = np.array(fine_data[attribute])
+    attr_data = attr_data[~np.isnan(attr_data)]
+
+    hist, edges = np.histogram(attr_data, density=True, bins=25)
+
+    fig = bk.figure(plot_width=width, plot_height=height,
+                    x_axis_label = attribute.title(),
+                    min_border_left=min_border_left, min_border_right=min_border_right,
+                    title = 'title')
+
+    fig.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:], fill_color=color, alpha=0.5)
+    fig.toolbar_location = None
+    fig.title.text_color = '#ffffff'
+    fig.yaxis.major_label_text_font_size = '0pt'
+
+    if attribute == 'TRANSP':
+        fig.xaxis.axis_label = 'Transparency'
+
+    if attribute == 'HOURANGLE':
+        fig.xaxis.axis_label = 'Hour Angle'
+
+    return fig
+
+def get_exposuresPerTile_hist(exposures, color, width=250, height=250, min_border_left=50, min_border_right=50):
+    '''
+    Generates a histogram of the number of exposures per tile for the given
+    exposures table
+    Args:
+        exposures: Table of exposures with column "TILEID"
+        color: String; color of the histogram
+    Options:
+        width, height: plot width and height in pixels
+        min_border_left, min_border_right: set minimum width for external labels in pixels
+        min_border_left, min_border_right: set minimum width for external labels in pixels
+    Returns bokeh Figure object
+    '''
+    keep = exposures['PROGRAM'] != 'CALIB'
+    
+    exposures_nocalib = exposures[keep]
+
+    exposures_nocalib["ones"] = 1
+    exposures_nocalib = exposures_nocalib["ones", "TILEID"]
+    exposures_nocalib = exposures_nocalib.group_by("TILEID")
+    exposures_nocalib = exposures_nocalib.groups.aggregate(np.sum)
+
+    hist, edges = np.histogram(exposures_nocalib["ones"], density=True, bins=np.arange(0, np.max(exposures_nocalib["ones"])+1))
+
+    fig = bk.figure(plot_width=width, plot_height=height,
+                    x_axis_label = "# Exposures per Tile",
+                    title = 'title',
+                    min_border_left=min_border_left, min_border_right=min_border_right)
+    fig.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:], fill_color=color, alpha=0.5)
+    fig.toolbar_location = None
+    fig.title.text_color = '#ffffff'
+    fig.yaxis.major_label_text_font_size = '0pt'
+
+    return fig

--- a/py/nightwatch/plots/summaryqa.py
+++ b/py/nightwatch/plots/summaryqa.py
@@ -151,10 +151,10 @@ def get_summarytable(exposures):
     source = ColumnDataSource(data=dict(
         nights = list(nights),
         totals = totals,
-        brights = brights,
-        grays = grays,
-        darks = darks,
-        calibs = calibs,
+        #brights = brights,
+        #grays = grays,
+        #darks = darks,
+        #calibs = calibs,
         med_air = med_air,
         med_seeing = med_seeing,
         med_exptime = med_exptime,
@@ -168,11 +168,11 @@ def get_summarytable(exposures):
 
     columns = [
         TableColumn(field='nights', title='NIGHT', width=100, formatter=HTMLTemplateFormatter(template=template_str)),
-        TableColumn(field='totals', title='Total', width=50),
-        TableColumn(field='brights', title='Bright', width=50),
-        TableColumn(field='grays', title='Gray', width=50),
-        TableColumn(field='darks', title='Dark', width=50),
-        TableColumn(field='calibs', title='Calibs', width=50),
+        TableColumn(field='totals', title='Total Exposures', width=100),
+        #TableColumn(field='brights', title='Bright', width=50),
+        #TableColumn(field='grays', title='Gray', width=50),
+        #TableColumn(field='darks', title='Dark', width=50),
+        #TableColumn(field='calibs', title='Calibs', width=50),
         TableColumn(field='med_exptime', title='Median Exp. Time', width=100),
         TableColumn(field='med_air', title='Median Airmass', width=100, formatter=formatter),
         TableColumn(field='med_seeing', title='Median Seeing', width=100, formatter=formatter),
@@ -181,7 +181,7 @@ def get_summarytable(exposures):
         TableColumn(field='med_angle', title='Median Hour Angle', width=115, formatter=formatter),
     ]
 
-    summary_table = DataTable(source=source, columns=columns, width=900, sortable=True, fit_columns=False)
+    summary_table = DataTable(source=source, columns=columns, width=750, sortable=True, fit_columns=False)
     return summary_table
 
 def get_hist(fine_data, attribute, color, width=250, height=250, min_border_left=50, min_border_right=50):

--- a/py/nightwatch/plots/summaryqa.py
+++ b/py/nightwatch/plots/summaryqa.py
@@ -97,7 +97,7 @@ def get_skyplot(exposures, tiles, width=500, height=250, min_border_left=50, min
 
     return fig
 
-def get_median(attribute, exposures):
+def get_median(attribute, exposures, nights):
     '''Get the median value for a given attribute for all nights for all exposures taken each night.
     Input:
         attributes: one of the labels in the exposure column, string
@@ -106,7 +106,7 @@ def get_median(attribute, exposures):
         returns a numpy array of the median values for each night
     '''
     medians = []
-    for n in np.unique(exposures['NIGHT']):
+    for n in nights:
         ii = (exposures['NIGHT'] == n)
         attrib = np.asarray(exposures[attribute])[ii]
         medians.append(np.ma.median(attrib))  #- use masked median
@@ -120,33 +120,31 @@ def get_summarytable(exposures):
         exposures: Table of exposures with columns...
     Returns a bokeh DataTable object.
     '''
+    #exposures_reversed = exposures.reverse()
+    
     nights = np.unique(exposures['NIGHT'])
 
-    isbright = (exposures['PROGRAM'] == 'BRIGHT')
-    isgray = (exposures['PROGRAM'] == 'GRAY')
-    isdark = (exposures['PROGRAM'] == 'DARK')
-    iscalib = (exposures['PROGRAM'] == 'CALIB')
+#     isbright = (exposures['PROGRAM'] == 'BRIGHT')
+#     isgray = (exposures['PROGRAM'] == 'GRAY')
+#     isdark = (exposures['PROGRAM'] == 'DARK')
+#     iscalib = (exposures['PROGRAM'] == 'CALIB')
 
     num_nights = len(nights)
-    brights = list()
-    grays = list()
-    darks = list()
-    calibs = list()
     totals = list()
     for n in nights:
         thisnight = exposures['NIGHT'] == n
         totals.append(np.count_nonzero(thisnight))
-        brights.append(np.count_nonzero(thisnight & isbright))
-        grays.append(np.count_nonzero(thisnight & isgray))
-        darks.append(np.count_nonzero(thisnight & isdark))
-        calibs.append(np.count_nonzero(thisnight & iscalib))
+#         brights.append(np.count_nonzero(thisnight & isbright))
+#         grays.append(np.count_nonzero(thisnight & isgray))
+#         darks.append(np.count_nonzero(thisnight & isdark))
+#         calibs.append(np.count_nonzero(thisnight & iscalib))
 
-    med_air = get_median('AIRMASS', exposures)
-    med_seeing = get_median('SEEING', exposures)
-    med_exptime = get_median('EXPTIME', exposures)
-    med_transp = get_median('TRANSP', exposures)
-    med_sky = get_median('SKY', exposures)
-    med_angle = get_median('HOURANGLE', exposures)
+    med_air = get_median('AIRMASS', exposures, nights)
+    med_seeing = get_median('SEEING', exposures, nights)
+    med_exptime = get_median('EXPTIME', exposures, nights)
+    med_transp = get_median('TRANSP', exposures, nights)
+    med_sky = get_median('SKY', exposures, nights)
+    med_angle = get_median('HOURANGLE', exposures, nights)
 
     source = ColumnDataSource(data=dict(
         nights = list(nights),

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -773,7 +773,17 @@ def write_thresholds(indir, outdir, start_date, end_date):
     print('Wrote {}'.format(htmlfile))
 
 def write_summaryqa(infile, name_dict, tiles, rawdir, outdir, nights=None, show_summary='all'):
-    '''docstring'''
+    '''Writes surveyqa html files.
+    Args:
+        infile: path to gfa_reduce files containing data that will be used to generate surveyqa files. (str)
+        name_dict: translates between columns in given infile and between those readable by surveyqa code.
+            Must have equivalents for AIRMASS, SKY, SEEING, TRANSP, RA, DEC, MJD, NIGHT, EXPID.
+        tiles: table of data on DESI tiles.
+        rawdir: directory containing raw data files.
+        outdir: directory to write files.
+    Options:
+        nights: subset of nights to generate nightly pages for.
+        show_summary: Whether to generate summary page for all available nights, a given subset, or not at all. Either "no", "all", or "subset". Default "all".'''
     
     from .webpages import summaryqa as web_summaryqa
     from .webpages import nightlyqa as web_nightlyqa

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -756,6 +756,7 @@ def write_thresholds(indir, outdir, start_date, end_date):
     print('Wrote {}'.format(htmlfile))
 
 def write_summaryqa(infile, tilefile, name_dict, rawdir, outdir, nights=None, show_summary='all'):
+    '''docstring'''
     
     from .webpages import summaryqa as web_summaryqa
     from .webpages import nightlyqa as web_nightlyqa

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -779,6 +779,9 @@ def write_summaryqa(infile, name_dict, tiles, rawdir, outdir, nights=None, show_
     from .webpages import nightlyqa as web_nightlyqa
     from . import io
     
+    if not os.path.isdir(os.path.join(outdir, 'surveyqa')):
+        os.mkdir(os.path.join(outdir, 'surveyqa'))
+    
     io.check_offline_files(outdir)
     
     exposures, fine_data = io.get_surveyqa_data(infile, name_dict, rawdir, program=True)

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -772,7 +772,7 @@ def write_thresholds(indir, outdir, start_date, end_date):
     plot_components.update(pc)
     print('Wrote {}'.format(htmlfile))
 
-def write_summaryqa(infile, tilefile, name_dict, rawdir, outdir, nights=None, show_summary='all'):
+def write_summaryqa(infile, name_dict, tiles, rawdir, outdir, nights=None, show_summary='all'):
     '''docstring'''
     
     from .webpages import summaryqa as web_summaryqa
@@ -782,8 +782,7 @@ def write_summaryqa(infile, tilefile, name_dict, rawdir, outdir, nights=None, sh
     io.check_offline_files(outdir)
     
     exposures, fine_data = io.get_surveyqa_data(infile, name_dict, rawdir, program=True)
-    tiles = Table.read(tilefile, hdu=1)
-
+    
     exposures_sub = exposures
     fine_data_sub = fine_data
     if nights is not None:

--- a/py/nightwatch/script.py
+++ b/py/nightwatch/script.py
@@ -23,6 +23,7 @@ Supported commands are:
     plot       Generate webpages with plots of QA output
     tables     Generate webpages with tables of nights and exposures
     webapp     Run a nightwatch Flask webapp server
+    surveyqa   Generate surveyqa webpages
 Run "nightwatch <command> --help" for details options about each command
 """)
 
@@ -53,6 +54,8 @@ def main():
         main_summary()
     elif command == 'threshold':
         main_threshold()
+    elif command == 'surveyqa':
+        main_surveyqa()
     else:
         print('ERROR: unrecognized command "{}"'.format(command))
         print_help()
@@ -371,3 +374,22 @@ def main_threshold(options=None):
     
     run.write_thresholds(args.indir, args.outdir, args.start, args.end)
     print('Wrote threshold jsons for each night to {}'.format('nightwatch/py/nightwatch/threshold_files'))
+
+def main_surveyqa(options=None):
+    parser = argparse.ArgumentParser(usage = '{prog} [options]')
+    
+    parser.add_argument('-i', '--infile', type=str, required=True, help='file containing data to feed into surveyqa')
+    parser.add_argument('-t', '--tilefile', type=str, required=True, help='file containing data on tiles')
+    parser.add_argument('-r', '--rawdir', type=str, required=True, help='directory containing raw data files (without YYYMMDD/EXPID/)')
+    parser.add_argument('-o', '--outdir', type=str, required=True, help='directory threshold json/html files should be written to')
+    
+    if options is None:
+        options = sys.argv[2:]
+    args = parser.parse_args(options)
+    
+    name_dict = {"EXPID": "EXPID", "MJD": "MJD", 
+             "AIRMASS": "AIRMASS", "TRANSP": "TRANSPARENCY", "NIGHT": "NIGHT", 
+             "MOONSEP": "MOON_SEP_DEG", "RA": "SKYRA", "DEC": "SKYDEC",
+             "SKY": "SKY_MAG_AB", "SEEING": "FWHM_ASEC"}
+
+    run.write_summaryqa(args.infile, args.tilefile, name_dict, args.rawdir, args.outdir)

--- a/py/nightwatch/script.py
+++ b/py/nightwatch/script.py
@@ -381,7 +381,7 @@ def main_surveyqa(options=None):
     parser.add_argument('-i', '--infile', type=str, required=True, help='file containing data to feed into surveyqa')
     parser.add_argument('-t', '--tilefile', type=str, required=True, help='file containing data on tiles')
     parser.add_argument('-r', '--rawdir', type=str, required=True, help='directory containing raw data files (without YYYMMDD/EXPID/)')
-    parser.add_argument('-o', '--outdir', type=str, required=True, help='directory threshold json/html files should be written to')
+    parser.add_argument('-o', '--outdir', type=str, required=True, help='directory threshold json/html files should be written to (will be written to outdir/surveyqa, outdir should be same location as other nightwatch files)')
     
     if options is None:
         options = sys.argv[2:]

--- a/py/nightwatch/webpages/nightlyqa.py
+++ b/py/nightwatch/webpages/nightlyqa.py
@@ -56,17 +56,17 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
     airmass = plot_timeseries_fine(fine_src, exp_src, 'AIRMASS', 'green', tools=TOOLS, 
                                    x_range=None, title=None, tooltips=TOOLTIPS, width=600, 
                                    height=time_hist_plot_height, min_border_left=min_border_left_time,
-                                   min_border_right=min_border_right_time)
+                                   min_border_right=min_border_right_time, y_range=(1, 2.5))
     
     seeing = plot_timeseries_fine(fine_src, exp_src, 'SEEING', 'navy', tools=TOOLS, 
                                   x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, 
                                   height=time_hist_plot_height, min_border_left=min_border_left_time,
-                                  min_border_right=min_border_right_time)
+                                  min_border_right=min_border_right_time, y_range=(0, 3.5))
     
     transp = plot_timeseries_fine(fine_src, exp_src, 'TRANSP', 'purple', tools=TOOLS, 
                                   x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, 
                                   height=time_hist_plot_height, min_border_left=min_border_left_time,
-                                  min_border_right=min_border_right_time)
+                                  min_border_right=min_border_right_time, y_range=(0, 2.5))
     
     hourangle = plot_timeseries_fine(fine_src, exp_src, 'HOURANGLE', 'maroon', tools=TOOLS, 
                                      x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, 
@@ -76,11 +76,11 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
     brightness = plot_timeseries_fine(fine_src, exp_src, 'SKY', 'pink', tools=TOOLS, 
                                       x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, 
                                       height=time_hist_plot_height, min_border_left=min_border_left_time,
-                                      min_border_right=min_border_right_time)
+                                      min_border_right=min_border_right_time, y_range=(17, 23))
     
     if len(exposures) != 0:
         exptime = plot_timeseries(exp_src, 'EXPTIME', 'darkorange', tools=TOOLS, x_range=airmass.x_range,
-                                  tooltips=TOOLTIPS, width=600, height=time_hist_plot_height,
+                                  tooltips=TOOLTIPS, width=600, height=time_hist_plot_height, y_range=(0, 950),
                                   min_border_left=min_border_left_time, min_border_right=min_border_right_time)
         
         #adding in the skyplot components
@@ -110,15 +110,15 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
     #- Get overlaid histograms for several variables
     airmasshist = overlaid_hist_fine(fine_data, night_fine_data, 'AIRMASS', 'green', 250, 
                                      time_hist_plot_height, min_border_left=min_border_left_hist,
-                                     min_border_right=min_border_right_hist)
+                                     min_border_right=min_border_right_hist, hist_min=1, hist_max=2.5)
     
     seeinghist = overlaid_hist_fine(fine_data, night_fine_data, 'SEEING', 'navy', 250, 
                                     time_hist_plot_height, min_border_left=min_border_left_hist,
-                                    min_border_right=min_border_right_hist)
+                                    min_border_right=min_border_right_hist, hist_min=0, hist_max=3.2)
     
     transphist = overlaid_hist_fine(fine_data, night_fine_data, 'TRANSP', 'purple', 250, 
                                     time_hist_plot_height, min_border_left=min_border_left_hist,
-                                    min_border_right=min_border_right_hist)
+                                    min_border_right=min_border_right_hist, hist_min=0, hist_max=2)
     
     hourangle = overlaid_hist_fine(fine_data, night_fine_data, "HOURANGLE", "maroon", 250, 
                                    time_hist_plot_height, min_border_left=min_border_left_hist,
@@ -126,12 +126,12 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
     
     brightnesshist = overlaid_hist_fine(fine_data, night_fine_data, 'SKY', 'pink', 250, 
                                         time_hist_plot_height, min_border_left=min_border_left_hist,
-                                        min_border_right=min_border_right_hist)
+                                        min_border_right=min_border_right_hist, hist_min=0, hist_max=23)
     
     if len(exposures) != 0:
         exptimehist = overlaid_hist(exposures, night_exposures, 'EXPTIME', 'darkorange', 250, 
                                     time_hist_plot_height, min_border_left=min_border_left_hist,
-                                    min_border_right=min_border_right_hist)
+                                    min_border_right=min_border_right_hist, hist_min=0)
         
         empty_plot = bk.figure(plot_width=250, plot_height=250)
         empty_plot.outline_line_color = None

--- a/py/nightwatch/webpages/nightlyqa.py
+++ b/py/nightwatch/webpages/nightlyqa.py
@@ -66,7 +66,7 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
     transp = plot_timeseries_fine(fine_src, exp_src, 'TRANSP', 'purple', tools=TOOLS, 
                                   x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, 
                                   height=time_hist_plot_height, min_border_left=min_border_left_time,
-                                  min_border_right=min_border_right_time, y_range=(0, 2.5))
+                                  min_border_right=min_border_right_time, y_range=(0, 2.2))
     
     hourangle = plot_timeseries_fine(fine_src, exp_src, 'HOURANGLE', 'maroon', tools=TOOLS, 
                                      x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, 
@@ -118,7 +118,7 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
     
     transphist = overlaid_hist_fine(fine_data, night_fine_data, 'TRANSP', 'purple', 250, 
                                     time_hist_plot_height, min_border_left=min_border_left_hist,
-                                    min_border_right=min_border_right_hist, hist_min=0, hist_max=2)
+                                    min_border_right=min_border_right_hist, hist_min=0, hist_max=1.05)
     
     hourangle = overlaid_hist_fine(fine_data, night_fine_data, "HOURANGLE", "maroon", 250, 
                                    time_hist_plot_height, min_border_left=min_border_left_hist,

--- a/py/nightwatch/webpages/nightlyqa.py
+++ b/py/nightwatch/webpages/nightlyqa.py
@@ -28,6 +28,12 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
     calibs = find_night(all_calibs, night)
     night_fine_data = find_night(fine_data, night)
 
+    html_components = dict(
+        bokeh_version=bokeh.__version__, night=night, 
+        summary_str = summary_str, next_str = next_str, 
+        prev_str = prev_str, first_str = first_str, 
+        last_str = last_str)
+    
     #- Plot options
     #title='Airmass, Seeing, Exptime vs. Time for {}/{}/{}'.format(night[4:6], night[6:], night[:4])
     TOOLS = ['box_zoom', 'reset', 'wheel_zoom']
@@ -52,64 +58,101 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
 
     time_hist_plot_height = 160
     
-    airmass = plot_timeseries_fine(fine_src, exp_src, 'AIRMASS', 'green', tools=TOOLS, x_range=None, title=None, tooltips=TOOLTIPS, width=600, height=time_hist_plot_height, min_border_left=min_border_left_time, min_border_right=min_border_right_time)
+    airmass = plot_timeseries_fine(fine_src, exp_src, 'AIRMASS', 'green', tools=TOOLS, 
+                                   x_range=None, title=None, tooltips=TOOLTIPS, width=600, 
+                                   height=time_hist_plot_height, min_border_left=min_border_left_time,
+                                   min_border_right=min_border_right_time)
     
-    seeing = plot_timeseries_fine(fine_src, exp_src, 'SEEING', 'navy', tools=TOOLS, x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, height=time_hist_plot_height, min_border_left=min_border_left_time, min_border_right=min_border_right_time)
+    seeing = plot_timeseries_fine(fine_src, exp_src, 'SEEING', 'navy', tools=TOOLS, 
+                                  x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, 
+                                  height=time_hist_plot_height, min_border_left=min_border_left_time,
+                                  min_border_right=min_border_right_time)
     
-    transp = plot_timeseries_fine(fine_src, exp_src, 'TRANSP', 'purple', tools=TOOLS, x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, height=time_hist_plot_height, min_border_left=min_border_left_time, min_border_right=min_border_right_time)
+    transp = plot_timeseries_fine(fine_src, exp_src, 'TRANSP', 'purple', tools=TOOLS, 
+                                  x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, 
+                                  height=time_hist_plot_height, min_border_left=min_border_left_time,
+                                  min_border_right=min_border_right_time)
     
-    hourangle = plot_timeseries_fine(fine_src, exp_src, 'HOURANGLE', 'maroon', tools=TOOLS, x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, height=time_hist_plot_height, min_border_left=min_border_left_time, min_border_right=min_border_right_time)
+    hourangle = plot_timeseries_fine(fine_src, exp_src, 'HOURANGLE', 'maroon', tools=TOOLS, 
+                                     x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, 
+                                     height=time_hist_plot_height, min_border_left=min_border_left_time,
+                                     min_border_right=min_border_right_time)
     
-    brightness = plot_timeseries_fine(fine_src, exp_src, 'SKY', 'pink', tools=TOOLS, x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, height=time_hist_plot_height, min_border_left=min_border_left_time, min_border_right=min_border_right_time)
+    brightness = plot_timeseries_fine(fine_src, exp_src, 'SKY', 'pink', tools=TOOLS, 
+                                      x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, 
+                                      height=time_hist_plot_height, min_border_left=min_border_left_time,
+                                      min_border_right=min_border_right_time)
     
-    exptime = plot_timeseries(exp_src, 'EXPTIME', 'darkorange', tools=TOOLS, x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, height=time_hist_plot_height, min_border_left=min_border_left_time, min_border_right=min_border_right_time)
+    if len(exposures) != 0:
+        exptime = plot_timeseries(exp_src, 'EXPTIME', 'darkorange', tools=TOOLS, x_range=airmass.x_range,
+                                  tooltips=TOOLTIPS, width=600, height=time_hist_plot_height,
+                                  min_border_left=min_border_left_time, min_border_right=min_border_right_time)
 
-    #- Convert these to the components to include in the HTML
-    timeseries_script, timeseries_div = components(bk.Column(exptime, airmass, seeing, transp, hourangle, brightness))
+        #- Convert these to the components to include in the HTML
+        script, div = components(bk.Column(exptime, airmass, seeing, transp, hourangle, brightness))
+        html_components['TIMESERIES'] = dict(script=script, div=div)
+    
+    else:
+        #- Convert these to the components to include in the HTML
+        script, div = components(bk.Column(airmass, seeing, transp, hourangle, brightness))
+        html_components['TIMESERIES'] = dict(script=script, div=div)
 
-    #making the nightly table of values
-    nightlytable = get_nightlytable(exposures)
-    table_script, table_div = components(nightlytable)
+    if len(exposures) != 0:
+        #making the nightly table of values
+        nightlytable = get_nightlytable(exposures)
+        script, div = components(nightlytable)
+        html_components['TABLE'] = dict(script=script, div=div)
 
-    #adding in the skyplot components
-    #skypathplot = get_skypathplot(exposures, tiles, width=600, height=250, min_border_left=min_border_left_sky, min_border_right=min_border_right_sky)
-    #skypathplot_script, skypathplot_div = components(skypathplot)
+        #adding in the skyplot components
+        skyplot = get_skypathplot(exposures, tiles, night, width=700, height=300, 
+                                  min_border_left=min_border_left_sky, min_border_right=min_border_right_sky)
+        script, div = components(skyplot)
+        html_components['SKYPATHPLOT'] = dict(script=script, div=div)
 
     #adding in the components of the exposure types bar plot
     #exptypecounts = get_exptype_counts(exposures, calibs, width=250, height=250, min_border_left=min_border_left_count, min_border_right=min_border_right_count)
     #exptypecounts_script, exptypecounts_div = components(exptypecounts)
 
     #- Get overlaid histograms for several variables
-    airmasshist = overlaid_hist_fine(fine_data, night_fine_data, 'AIRMASS', 'green', 250, time_hist_plot_height, min_border_left=min_border_left_hist, min_border_right=min_border_right_hist)
+    airmasshist = overlaid_hist_fine(fine_data, night_fine_data, 'AIRMASS', 'green', 250, 
+                                     time_hist_plot_height, min_border_left=min_border_left_hist,
+                                     min_border_right=min_border_right_hist)
     
-    seeinghist = overlaid_hist_fine(fine_data, night_fine_data, 'SEEING', 'navy', 250, time_hist_plot_height, min_border_left=min_border_left_hist, min_border_right=min_border_right_hist)
+    seeinghist = overlaid_hist_fine(fine_data, night_fine_data, 'SEEING', 'navy', 250, 
+                                    time_hist_plot_height, min_border_left=min_border_left_hist,
+                                    min_border_right=min_border_right_hist)
     
-    transphist = overlaid_hist_fine(fine_data, night_fine_data, 'TRANSP', 'purple', 250, time_hist_plot_height, min_border_left=min_border_left_hist, min_border_right=min_border_right_hist)
+    transphist = overlaid_hist_fine(fine_data, night_fine_data, 'TRANSP', 'purple', 250, 
+                                    time_hist_plot_height, min_border_left=min_border_left_hist,
+                                    min_border_right=min_border_right_hist)
     
-    hourangle = overlaid_hist_fine(fine_data, night_fine_data, "HOURANGLE", "maroon", 250, time_hist_plot_height, min_border_left=min_border_left_hist, min_border_right=min_border_right_hist)
+    hourangle = overlaid_hist_fine(fine_data, night_fine_data, "HOURANGLE", "maroon", 250, 
+                                   time_hist_plot_height, min_border_left=min_border_left_hist,
+                                   min_border_right=min_border_right_hist)
     
-    brightnesshist = overlaid_hist_fine(fine_data, night_fine_data, 'SKY', 'pink', 250, time_hist_plot_height, min_border_left=min_border_left_hist, min_border_right=min_border_right_hist)
+    brightnesshist = overlaid_hist_fine(fine_data, night_fine_data, 'SKY', 'pink', 250, 
+                                        time_hist_plot_height, min_border_left=min_border_left_hist,
+                                        min_border_right=min_border_right_hist)
     
-    exptimehist = overlaid_hist(all_exposures, exposures, 'EXPTIME', 'darkorange', 250, time_hist_plot_height, min_border_left=min_border_left_hist, min_border_right=min_border_right_hist)
+    if len(exposures) != 0:
+    
+        exptimehist = overlaid_hist(all_exposures, exposures, 'EXPTIME', 'darkorange', 250, 
+                                    time_hist_plot_height, min_border_left=min_border_left_hist,
+                                    min_border_right=min_border_right_hist)
 
-    #adding in the components of the overlaid histograms
-    overlaidhists_script, overlaidhists_div = components(bk.Column(exptimehist, airmasshist, seeinghist, transphist, hourangle, brightnesshist))
+        #adding in the components of the overlaid histograms
+        script, div = components(bk.Column(exptimehist, airmasshist, seeinghist, transphist, hourangle, brightnesshist))
+        html_components['HIST'] = dict(script=script, div=div)
+    
+    else:
+        script, div = components(bk.Column(airmasshist, seeinghist, transphist, hourangle, brightnesshist))
+        html_components['HIST'] = dict(script=script, div=div)
     
     env = jinja2.Environment(
         loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
     )
     
     template = env.get_template('nightlyqa.html')
-    
-    html_components = dict(
-        bokeh_version=bokeh.__version__, night=night, summary_str = summary_str,
-        next_str = next_str, prev_str = prev_str, first_str = first_str, last_str = last_str,
-        #skypathplot_script=skypathplot_script, skypathplot_div=skypathplot_div,
-        #exptypecounts_script=exptypecounts_script, exptypecounts_div=exptypecounts_div,
-        timeseries_script=timeseries_script, timeseries_div=timeseries_div,
-        overlaidhists_script=overlaidhists_script, overlaidhists_div=overlaidhists_div,
-        table_script=table_script, table_div=table_div,
-        )
     
      #- Combine template + components -> HTML
     html = template.render(**html_components)

--- a/py/nightwatch/webpages/nightlyqa.py
+++ b/py/nightwatch/webpages/nightlyqa.py
@@ -119,5 +119,7 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
     
     with open(outfile, 'w') as fx:
         fx.write(html)
+    
+    print('Wrote {}'.format(outfile))
 
     return html_components

--- a/py/nightwatch/webpages/nightlyqa.py
+++ b/py/nightwatch/webpages/nightlyqa.py
@@ -19,13 +19,8 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
     next_str = night_links['next']
     prev_str = night_links['prev']
 
-    #- Separate calibration exposures
-    all_exposures = exposures[exposures['PROGRAM'] != 'CALIB']
-    all_calibs = exposures[exposures['PROGRAM'] == 'CALIB']
-
     #- Filter exposures to just this night and adds columns DATETIME and MJD_hour
-    exposures = find_night(all_exposures, night)
-    calibs = find_night(all_calibs, night)
+    night_exposures = find_night(exposures, night)
     night_fine_data = find_night(fine_data, night)
 
     html_components = dict(
@@ -43,7 +38,7 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
     #- Create ColumnDataSource for linking timeseries plots
     COLS = ['EXPID', 'TIME', 'AIRMASS', 'SEEING', 'EXPTIME', 'TRANSP', 'SKY', 'HOURANGLE']
     fine_COLS = ['EXPID', 'TIME', 'AIRMASS', 'SEEING', 'TRANSP', 'SKY', 'HOURANGLE']
-    exp_src = ColumnDataSource(data={c:np.array(exposures[c]) for c in COLS})
+    exp_src = ColumnDataSource(data={c:np.array(night_exposures[c]) for c in COLS})
     fine_src = ColumnDataSource(data={c:np.array(night_fine_data[c]) for c in fine_COLS})
 
     #- Get timeseries plots for several variables
@@ -99,12 +94,12 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
 
     if len(exposures) != 0:
         #making the nightly table of values
-        nightlytable = get_nightlytable(exposures)
+        nightlytable = get_nightlytable(night_exposures)
         script, div = components(nightlytable)
         html_components['TABLE'] = dict(script=script, div=div)
 
         #adding in the skyplot components
-        skyplot = get_skypathplot(exposures, tiles, night, width=700, height=300, 
+        skyplot = get_skypathplot(night_exposures, tiles, night, width=650, height=250, 
                                   min_border_left=min_border_left_sky, min_border_right=min_border_right_sky)
         script, div = components(skyplot)
         html_components['SKYPATHPLOT'] = dict(script=script, div=div)
@@ -136,7 +131,7 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
     
     if len(exposures) != 0:
     
-        exptimehist = overlaid_hist(all_exposures, exposures, 'EXPTIME', 'darkorange', 250, 
+        exptimehist = overlaid_hist(exposures, night_exposures, 'EXPTIME', 'darkorange', 250, 
                                     time_hist_plot_height, min_border_left=min_border_left_hist,
                                     min_border_right=min_border_right_hist)
 

--- a/py/nightwatch/webpages/nightlyqa.py
+++ b/py/nightwatch/webpages/nightlyqa.py
@@ -10,7 +10,7 @@ from bokeh.models import ColumnDataSource
 from ..plots.nightlyqa import find_night, get_timeseries, plot_timeseries, get_nightlytable, get_moonloc, get_skypathplot, overlaid_hist, overlaid_hist_fine, get_exptype_counts, plot_timeseries_fine
 
 def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, height=250, width=250):
-    '''docstring'''
+    '''outdir: same as directory where nightwatch files are generated. will be created in a new surveyqa subdirectory.'''
     
     summary_str = "summaryqa.html"
     last_str = link_dict['last']
@@ -115,7 +115,7 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
     html = template.render(**html_components)
 
     #- Write HTML text to the output file
-    outfile = os.path.join(outdir, 'nightqa-{}.html'.format(night))
+    outfile = os.path.join(outdir, 'surveyqa/nightqa-{}.html'.format(night))
     
     with open(outfile, 'w') as fx:
         fx.write(html)

--- a/py/nightwatch/webpages/nightlyqa.py
+++ b/py/nightwatch/webpages/nightlyqa.py
@@ -1,0 +1,123 @@
+import numpy as np
+import os
+
+import jinja2
+import bokeh
+import bokeh.plotting as bk
+from bokeh.embed import components
+from bokeh.models import ColumnDataSource
+
+from ..plots.nightlyqa import find_night, get_timeseries, plot_timeseries, get_nightlytable, get_moonloc, get_skypathplot, overlaid_hist, overlaid_hist_fine, get_exptype_counts, plot_timeseries_fine
+
+def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, height=250, width=250):
+    '''docstring'''
+    
+    summary_str = "summaryqa.html"
+    last_str = link_dict['last']
+    first_str = link_dict['first']
+    night_links = link_dict['n{}'.format(night)]
+    next_str = night_links['next']
+    prev_str = night_links['prev']
+
+    #- Separate calibration exposures
+    all_exposures = exposures[exposures['PROGRAM'] != 'CALIB']
+    all_calibs = exposures[exposures['PROGRAM'] == 'CALIB']
+
+    #- Filter exposures to just this night and adds columns DATETIME and MJD_hour
+    exposures = find_night(all_exposures, night)
+    calibs = find_night(all_calibs, night)
+    night_fine_data = find_night(fine_data, night)
+
+    #- Plot options
+    #title='Airmass, Seeing, Exptime vs. Time for {}/{}/{}'.format(night[4:6], night[6:], night[:4])
+    TOOLS = ['box_zoom', 'reset', 'wheel_zoom']
+    TOOLTIPS = [("EXPID", "@EXPID"), ("Exposure Time", "@EXPTIME"), ("Airmass", "@AIRMASS"), 
+                ("Seeing", "@SEEING"), ("Transparency", "@TRANSP"), ('Hour Angle', '@HOURANGLE')]
+    
+    #- Create ColumnDataSource for linking timeseries plots
+    COLS = ['EXPID', 'TIME', 'AIRMASS', 'SEEING', 'EXPTIME', 'TRANSP', 'SKY', 'HOURANGLE']
+    fine_COLS = ['EXPID', 'TIME', 'AIRMASS', 'SEEING', 'TRANSP', 'SKY', 'HOURANGLE']
+    exp_src = ColumnDataSource(data={c:np.array(exposures[c]) for c in COLS})
+    fine_src = ColumnDataSource(data={c:np.array(night_fine_data[c]) for c in fine_COLS})
+
+    #- Get timeseries plots for several variables
+    min_border_right_time = 0
+    min_border_left_time = 60
+    min_border_right_hist = 0
+    min_border_left_hist = 70
+    min_border_right_count = 0
+    min_border_left_count = 70
+    min_border_right_sky = 0
+    min_border_left_sky = 60
+
+    time_hist_plot_height = 160
+    
+    airmass = plot_timeseries_fine(fine_src, exp_src, 'AIRMASS', 'green', tools=TOOLS, x_range=None, title=None, tooltips=TOOLTIPS, width=600, height=time_hist_plot_height, min_border_left=min_border_left_time, min_border_right=min_border_right_time)
+    
+    seeing = plot_timeseries_fine(fine_src, exp_src, 'SEEING', 'navy', tools=TOOLS, x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, height=time_hist_plot_height, min_border_left=min_border_left_time, min_border_right=min_border_right_time)
+    
+    transp = plot_timeseries_fine(fine_src, exp_src, 'TRANSP', 'purple', tools=TOOLS, x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, height=time_hist_plot_height, min_border_left=min_border_left_time, min_border_right=min_border_right_time)
+    
+    hourangle = plot_timeseries_fine(fine_src, exp_src, 'HOURANGLE', 'maroon', tools=TOOLS, x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, height=time_hist_plot_height, min_border_left=min_border_left_time, min_border_right=min_border_right_time)
+    
+    brightness = plot_timeseries_fine(fine_src, exp_src, 'SKY', 'pink', tools=TOOLS, x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, height=time_hist_plot_height, min_border_left=min_border_left_time, min_border_right=min_border_right_time)
+    
+    exptime = plot_timeseries(exp_src, 'EXPTIME', 'darkorange', tools=TOOLS, x_range=airmass.x_range, tooltips=TOOLTIPS, width=600, height=time_hist_plot_height, min_border_left=min_border_left_time, min_border_right=min_border_right_time)
+
+    #- Convert these to the components to include in the HTML
+    timeseries_script, timeseries_div = components(bk.Column(exptime, airmass, seeing, transp, hourangle, brightness))
+
+    #making the nightly table of values
+    nightlytable = get_nightlytable(exposures)
+    table_script, table_div = components(nightlytable)
+
+    #adding in the skyplot components
+    #skypathplot = get_skypathplot(exposures, tiles, width=600, height=250, min_border_left=min_border_left_sky, min_border_right=min_border_right_sky)
+    #skypathplot_script, skypathplot_div = components(skypathplot)
+
+    #adding in the components of the exposure types bar plot
+    #exptypecounts = get_exptype_counts(exposures, calibs, width=250, height=250, min_border_left=min_border_left_count, min_border_right=min_border_right_count)
+    #exptypecounts_script, exptypecounts_div = components(exptypecounts)
+
+    #- Get overlaid histograms for several variables
+    airmasshist = overlaid_hist_fine(fine_data, night_fine_data, 'AIRMASS', 'green', 250, time_hist_plot_height, min_border_left=min_border_left_hist, min_border_right=min_border_right_hist)
+    
+    seeinghist = overlaid_hist_fine(fine_data, night_fine_data, 'SEEING', 'navy', 250, time_hist_plot_height, min_border_left=min_border_left_hist, min_border_right=min_border_right_hist)
+    
+    transphist = overlaid_hist_fine(fine_data, night_fine_data, 'TRANSP', 'purple', 250, time_hist_plot_height, min_border_left=min_border_left_hist, min_border_right=min_border_right_hist)
+    
+    hourangle = overlaid_hist_fine(fine_data, night_fine_data, "HOURANGLE", "maroon", 250, time_hist_plot_height, min_border_left=min_border_left_hist, min_border_right=min_border_right_hist)
+    
+    brightnesshist = overlaid_hist_fine(fine_data, night_fine_data, 'SKY', 'pink', 250, time_hist_plot_height, min_border_left=min_border_left_hist, min_border_right=min_border_right_hist)
+    
+    exptimehist = overlaid_hist(all_exposures, exposures, 'EXPTIME', 'darkorange', 250, time_hist_plot_height, min_border_left=min_border_left_hist, min_border_right=min_border_right_hist)
+
+    #adding in the components of the overlaid histograms
+    overlaidhists_script, overlaidhists_div = components(bk.Column(exptimehist, airmasshist, seeinghist, transphist, hourangle, brightnesshist))
+    
+    env = jinja2.Environment(
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+    )
+    
+    template = env.get_template('nightlyqa.html')
+    
+    html_components = dict(
+        bokeh_version=bokeh.__version__, night=night, summary_str = summary_str,
+        next_str = next_str, prev_str = prev_str, first_str = first_str, last_str = last_str,
+        #skypathplot_script=skypathplot_script, skypathplot_div=skypathplot_div,
+        #exptypecounts_script=exptypecounts_script, exptypecounts_div=exptypecounts_div,
+        timeseries_script=timeseries_script, timeseries_div=timeseries_div,
+        overlaidhists_script=overlaidhists_script, overlaidhists_div=overlaidhists_div,
+        table_script=table_script, table_div=table_div,
+        )
+    
+     #- Combine template + components -> HTML
+    html = template.render(**html_components)
+
+    #- Write HTML text to the output file
+    outfile = os.path.join(outdir, 'nightqa-{}.html'.format(night))
+    
+    with open(outfile, 'w') as fx:
+        fx.write(html)
+
+    return html_components

--- a/py/nightwatch/webpages/summaryqa.py
+++ b/py/nightwatch/webpages/summaryqa.py
@@ -1,0 +1,70 @@
+import numpy as np
+import os
+
+import jinja2
+import bokeh
+from bokeh.embed import components
+
+from ..plots.summaryqa import get_skyplot, get_summarytable, get_hist, get_exposuresPerTile_hist, get_median
+
+
+def get_summaryqa_html(exposures, fine_data, tiles, outdir, height=250, width=250):   
+    '''docstring'''
+    
+    env = jinja2.Environment(
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+    )
+    
+    template = env.get_template('summaryqa.html')
+    
+    min_border = 30
+
+    skyplot = get_skyplot(exposures, tiles, height=300, width=600, min_border_left=min_border, min_border_right=min_border)
+    skyplot_script, skyplot_div = components(skyplot)
+
+    summarytable = get_summarytable(exposures)
+    summarytable_script, summarytable_div = components(summarytable)
+
+    seeing_hist = get_hist(fine_data, "SEEING", "navy", height=height, width=width, min_border_left=min_border, min_border_right=min_border)
+    seeing_script, seeing_div = components(seeing_hist)
+
+    airmass_hist = get_hist(fine_data, "AIRMASS", "green", height=height, width=width, min_border_left=min_border, min_border_right=min_border)
+    airmass_script, airmass_div = components(airmass_hist)
+
+    transp_hist = get_hist(fine_data, "TRANSP", "purple", height=height, width=width, min_border_left=min_border, min_border_right=min_border)
+    transp_hist_script, transp_hist_div = components(transp_hist)
+    
+    exptime_hist = get_hist(exposures, "EXPTIME", "darkorange", height=height, width=width, min_border_left=min_border, min_border_right=min_border)
+    exptime_script, exptime_div = components(exptime_hist)
+    
+    brightnessplot = get_hist(fine_data, "SKY", "pink", height=height, width=width, min_border_left=min_border, min_border_right=min_border)
+    brightness_script, brightness_div = components(brightnessplot)
+    
+    exposePerTile_hist = get_exposuresPerTile_hist(exposures, "orange", height=height, width=width, min_border_left=min_border, min_border_right=min_border)
+    exposePerTile_hist_script, exposePerTile_hist_div = components(exposePerTile_hist)
+    
+
+    #- Convert to a jinja2.Template object and render HTML
+    html_components = dict(
+        bokeh_version=bokeh.__version__, last_night = max(exposures["NIGHT"]),
+        skyplot_script=skyplot_script, skyplot_div=skyplot_div,
+        summarytable_script=summarytable_script, summarytable_div=summarytable_div,
+        airmass_script=airmass_script, airmass_div=airmass_div,
+        seeing_script=seeing_script, seeing_div=seeing_div,
+        exptime_script=exptime_script, exptime_div=exptime_div,
+        transp_hist_script=transp_hist_script, transp_hist_div=transp_hist_div,
+        exposePerTile_hist_script=exposePerTile_hist_script, exposePerTile_hist_div=exposePerTile_hist_div,
+        brightness_script=brightness_script, brightness_div=brightness_div,
+        )
+    
+    #- Combine template + components -> HTML
+    html = template.render(**html_components)
+
+    #- Write HTML text to the output file
+    outfile = os.path.join(outdir, 'summaryqa.html')
+    with open(outfile, 'w') as fx:
+        fx.write(html)
+        
+    print('Wrote {}'.format(outfile))
+
+    return html_components

--- a/py/nightwatch/webpages/summaryqa.py
+++ b/py/nightwatch/webpages/summaryqa.py
@@ -9,7 +9,7 @@ from ..plots.summaryqa import get_skyplot, get_summarytable, get_hist, get_expos
 
 
 def get_summaryqa_html(exposures, fine_data, tiles, outdir, height=250, width=250):   
-    '''docstring'''
+    '''outdir: same as directory where nightwatch files are generated. will be created in a new surveyqa subdirectory.'''
     
     env = jinja2.Environment(
         loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
@@ -61,7 +61,7 @@ def get_summaryqa_html(exposures, fine_data, tiles, outdir, height=250, width=25
     html = template.render(**html_components)
 
     #- Write HTML text to the output file
-    outfile = os.path.join(outdir, 'summaryqa.html')
+    outfile = os.path.join(outdir, 'surveyqa/summaryqa.html')
     with open(outfile, 'w') as fx:
         fx.write(html)
         

--- a/py/nightwatch/webpages/templates/exposures.html
+++ b/py/nightwatch/webpages/templates/exposures.html
@@ -6,6 +6,7 @@
 </ul>
 <ul class="navigationbar">
   <li style="float:left"><a href="../nights.html">Calendar</a></li>
+  <li style="float:left"><a href="../surveyqa/nightqa-{{ night }}.html">SurveyQA</a></li>
   <li><a id="next">next</a></li>
   <li><a id="prev">prev</a></li>
   <li><a href="../qa-lastexp.html">latest</a></li>

--- a/py/nightwatch/webpages/templates/nightlyqa.html
+++ b/py/nightwatch/webpages/templates/nightlyqa.html
@@ -58,13 +58,23 @@
 
 <div class="flex-container">
     <div class="column middle">
+        
+        {% if SKYPATHPLOT %}
+        <div class='flex-container'>{{ SKYPATHPLOT.script }} {{ SKYPATHPLOT.div }}</div>
+        {% endif %}
             
         <div class="flex-container">
-            <div>{{ timeseries_script }} {{ timeseries_div }}</div>
-            <div>{{ overlaidhists_script }} {{ overlaidhists_div }}</div>
+            {% if TIMESERIES %}
+            <div>{{ TIMESERIES.script }} {{ TIMESERIES.div }}</div>
+            {% endif %}
+            {% if HIST %}
+            <div>{{ HIST.script }} {{ HIST.div }}</div>
+            {% endif %}
         </div>
         
-        <div class="flex-container">{{ table_script }}{{ table_div }}</div>
+        {% if TABLE %}
+        <div class="flex-container">{{ TABLE.script }}{{ TABLE.div }}</div>
+        {% endif %}
     </div>
 </div>
     

--- a/py/nightwatch/webpages/templates/nightlyqa.html
+++ b/py/nightwatch/webpages/templates/nightlyqa.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<style>
+    body {
+        margin: 0;
+    }
+    .header {
+        font-family: "Open Serif", Arial, Helvetica, sans-serif;
+        background-color: #f1f1f1;
+        padding: 10px;
+        text-align: center;
+        justify: space-around;
+    }
+    .column {
+        float: center;
+        padding: 10px
+    }
+    .column.side {
+        width = 5%;
+    }
+    .column.middle {
+        width = 90%;
+    }
+    .flex-container {
+        display: flex;
+        flex-direction: row;
+        flex-flow: row wrap;
+        justify-content: center;
+        padding: 10px;
+    }
+    p.sansserif {
+        font-family: "Open Serif", Helvetica, sans-serif;
+    }
+    ul {
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+      background-color: #333;
+    }
+    li {
+      float: right;
+    }
+    li a {
+      display: block;
+      color: white;
+      text-align: center;
+      padding: 20px;
+      text-decoration: none;
+      font-family: "Open Serif", "Arial", sans-serif;
+    }
+    li a:hover {
+      background-color: #111;
+    }
+    li a.noHover{
+      pointer-events: none;
+    }
+    </style>
+
+<body>
+
+<ul class="navigationbar">
+  {# Left side navigations links (from left to right)#}
+  <li style="float:left"><a>DESI Survey QA Night {{ night }}</a></li>
+  <li><a id="last" href={{ last_str }}>Last</a></li>
+  <li><a id="next" href={{ next_str }}>Next</a></li>
+  <li><a id="prev" href={{ prev_str }}>Prev</a></li>
+  <li><a id="first" href={{ first_str }}>First</a></li>
+    <li><a href = {{ summary_str }}>Summary Page</a></li>
+</ul>
+    
+<div class="flex-container">
+    <div class="column middle">
+            
+        <div class="flex-container">
+            <div>{{ timeseries_script }} {{ timeseries_div }}</div>
+            <div>{{ overlaidhists_script }} {{ overlaidhists_div }}</div>
+        </div>
+        
+        <div class="flex-container">{{ table_script }}{{ table_div }}</div>
+    </div>
+</div>
+    
+{% endblock %}

--- a/py/nightwatch/webpages/templates/nightlyqa.html
+++ b/py/nightwatch/webpages/templates/nightlyqa.html
@@ -30,47 +30,32 @@
         justify-content: center;
         padding: 10px;
     }
+    .flex-container.title{
+        justify-content: space-around;
+        flex-direction: column;
+    }
     p.sansserif {
         font-family: "Open Serif", Helvetica, sans-serif;
     }
-    ul {
-      list-style-type: none;
-      margin: 0;
-      padding: 0;
-      overflow: hidden;
-      background-color: #333;
-    }
-    li {
-      float: right;
-    }
-    li a {
-      display: block;
-      color: white;
-      text-align: center;
-      padding: 20px;
-      text-decoration: none;
-      font-family: "Open Serif", "Arial", sans-serif;
-    }
-    li a:hover {
-      background-color: #111;
-    }
-    li a.noHover{
-      pointer-events: none;
-    }
-    </style>
+</style>
 
-<body>
+<div class="flex-container title">
+    <ul class="titlebar">
+        <li><a>DESI SurveyQA Night {{ night }}</a></li>
+    </ul>
 
-<ul class="navigationbar">
-  {# Left side navigations links (from left to right)#}
-  <li style="float:left"><a>DESI Survey QA Night {{ night }}</a></li>
-  <li><a id="last" href={{ last_str }}>Last</a></li>
-  <li><a id="next" href={{ next_str }}>Next</a></li>
-  <li><a id="prev" href={{ prev_str }}>Prev</a></li>
-  <li><a id="first" href={{ first_str }}>First</a></li>
-    <li><a href = {{ summary_str }}>Summary Page</a></li>
-</ul>
-    
+    <ul class="navigationbar">
+        {# Left side navigations links (from left to right)#}
+        <li style="float:left"><a href="../nights.html">Calendar</a></li>
+        <li style="float:left"><a href="../{{ night }}/exposures.html">Nightwatch</a></li>
+        <li><a id="last" href={{ last_str }}>Last</a></li>
+        <li><a id="next" href={{ next_str }}>Next</a></li>
+        <li><a id="prev" href={{ prev_str }}>Prev</a></li>
+        <li><a id="first" href={{ first_str }}>First</a></li>
+        <li><a id="summary" href = {{ summary_str }}>Summary Page</a></li>
+    </ul>
+</div>
+
 <div class="flex-container">
     <div class="column middle">
             

--- a/py/nightwatch/webpages/templates/nights.html
+++ b/py/nightwatch/webpages/templates/nights.html
@@ -17,22 +17,47 @@
 <div id="titlebar">
   <center><font size="6" text_align="center">DESI Nightwatch</font></center>
 </div>
+    
+<div class="container">
+    <div id="button">
+        <a href="surveyqa/summaryqa.html" target="_blank">SurveyQA</a>
+    </div>
+</div>
+    
+{#
+<div class="container" padding=6px>
+    <a href="timeseries">timeseries plots</a>
+</div>
+#}
 
 <div class="container">
     <div class="calendar"></div>
 </div>
-
-{#
-<div class="container">
-    <a href="timeseries">timeseries plots</a>
-</div>
-#}
 
 <style>
 #titlebar {
     padding: 6px;
     color: gold;
     background-color: #333;
+}
+
+a:link, a:visited {
+  background-color: gold;
+  color: #333;
+  padding: 6px 24px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 18px;
+}
+
+a:hover, a:active {
+  background-color: #FFEB65;
+}
+
+#button {
+    padding: 6px;
+    float: left;
 }
 </style>
 

--- a/py/nightwatch/webpages/templates/summaryqa.html
+++ b/py/nightwatch/webpages/templates/summaryqa.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<style>
+    body {
+        margin: 0;
+    }
+    .header {
+        font-family: "Open Serif", Arial, Helvetica, sans-serif;
+        background-color: #f1f1f1;
+        padding: 10px;
+        text-align: left;
+        justify: space-around;
+    }
+    .column {
+        float: center;
+    }
+    .column.side {
+        width = 10%;
+    }
+    .column.middle {
+        width = 80%;
+    }
+    .flex-container {
+        display: flex;
+        flex-direction: row;
+        flex-flow: row wrap;
+        justify-content: flex-start;
+        padding: 10px;
+        align-items: flex-end;
+    }
+    p.sansserif {
+        font-family: "Open Serif", Helvetica, sans-serif;
+    }
+</style>
+
+<div class="flex-container">
+    <div class="column side"></div>
+    <div class="column middle">
+        <div class="header">
+            <p class='sansserif'>DESI Survey QA through {{ last_night }}</p>
+        </div>
+            
+        <div class="flex-container">
+            <div>{{ skyplot_script }} {{ skyplot_div }}</div>
+        </div>
+            
+        <div class="header">
+            <p class="sansserif">Observing Conditions</p>
+        </div>
+            
+        <div class="flex-container">
+            <div>{{ airmass_script }} {{ airmass_div }}</div>
+            <div>{{ seeing_script }} {{ seeing_div }}</div>
+            <div>{{ transp_hist_script }} {{ transp_hist_div }}</div>
+            <div>{{ exposePerTile_hist_script }} {{ exposePerTile_hist_div }}</div>
+            <div>{{ brightness_script }} {{ brightness_div }}</div>
+            <div>{{ exptime_script }} {{ exptime_div }}</div>
+        </div>
+                
+        <div class="header">
+            <p class="sansserif">Summary Table</p>
+        </div>
+                
+        <div class="flex-container">
+            {{ summarytable_script }}
+            {{ summarytable_div }}
+        </div>
+            
+    </div>
+    <div class="column side"></div>
+</div>
+{% endblock %}

--- a/py/nightwatch/webpages/templates/summaryqa.html
+++ b/py/nightwatch/webpages/templates/summaryqa.html
@@ -6,13 +6,7 @@
     body {
         margin: 0;
     }
-    .header {
-        font-family: "Open Serif", Arial, Helvetica, sans-serif;
-        background-color: #f1f1f1;
-        padding: 10px;
-        text-align: left;
-        justify: space-around;
-    }
+    
     .column {
         float: center;
     }
@@ -30,25 +24,27 @@
         padding: 10px;
         align-items: flex-end;
     }
-    p.sansserif {
-        font-family: "Open Serif", Helvetica, sans-serif;
-    }
 </style>
 
 <div class="flex-container">
     <div class="column side"></div>
     <div class="column middle">
-        <div class="header">
-            <p class='sansserif'>DESI Survey QA through {{ last_night }}</p>
-        </div>
+        
+        <ul class="titlebar">
+           <li><a>DESI SurveyQA through {{ last_night }}</a></li>
+        </ul>
+        
+        <ul class="navigationbar">
+          <li style="float:left"><a id="nights" href = "../nights.html">calendar</a></li>
+        </ul>
             
         <div class="flex-container">
             <div>{{ skyplot_script }} {{ skyplot_div }}</div>
         </div>
             
-        <div class="header">
-            <p class="sansserif">Observing Conditions</p>
-        </div>
+        <ul class="titlebar">
+            <li><a>Observing Conditions</a></li>
+        </ul>
             
         <div class="flex-container">
             <div>{{ airmass_script }} {{ airmass_div }}</div>
@@ -59,9 +55,9 @@
             <div>{{ exptime_script }} {{ exptime_div }}</div>
         </div>
                 
-        <div class="header">
-            <p class="sansserif">Summary Table</p>
-        </div>
+         <ul class="titlebar">
+            <li><a>Summary Table</a></li>
+        </ul>
                 
         <div class="flex-container">
             {{ summarytable_script }}


### PR DESCRIPTION
Added new command `nightwatch surveyqa`. Here's how to run it:

`nightwatch surveyqa -i [infile] -t [tilefile] -o [outdir] -r [rawdir]`

Inputs:
- infile: path to file containing data to feed into surveyqa; as of right now, code is only written to use outputs from gfa_reduce; I have been using Aaron Meisner's fits files found in /global/cfs/cdirs/desi/users/ameisner/GFA/conditions/ at NERSC. 
- tilefile: path to the desi-tiles.fits file found in $DESIMODEL/data/footprint.
- outdir: directory to write surveyqa html files (for linking to work as of right now, make sure this is the same directory that nightwatch html files are written to).
- rawdir: directory containing raw data (desi-*.fits) files.

Running this will generate a summaryqa.html file and nightqa-*.fits file for each night in the data provided. As of right now, these pages do not link to the central nightwatch pages, but they will in the future. In addition, I'm still working to add more plots/functionality to these pages.