### PR TITLE
error handling missing guide-rois

### DIFF
--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -427,7 +427,7 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
             htmlfile = '{}/qa-guide-{:08d}.html'.format(expdir, expid)
             web_guide.write_guide_html(htmlfile, header, guidedata)
             print('Wrote {}'.format(htmlfile))
-        except FileNotFoundError:
+        except FileNotFoundError or OSError:
             print('Unable to find guide data, not plotting guide plots')
         
         #- plot guide image movies
@@ -436,7 +436,7 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
             image_data = io.get_guide_images(night, expid, rawdir)
             web_guideimage.write_guide_image_html(image_data, htmlfile, night, expid)
             print('Wrote {}'.format(htmlfile))
-        except FileNotFoundError:
+        except FileNotFoundError or OSError:
             print('Unable to find guide data, not plotting guide image plots')
 
     #- regardless of if logdir or preprocdir, identifying failed qprocs by comparing

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -427,7 +427,7 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
             htmlfile = '{}/qa-guide-{:08d}.html'.format(expdir, expid)
             web_guide.write_guide_html(htmlfile, header, guidedata)
             print('Wrote {}'.format(htmlfile))
-        except FileNotFoundError or OSError:
+        except (FileNotFoundError, OSError, IOError):
             print('Unable to find guide data, not plotting guide plots')
         
         #- plot guide image movies
@@ -436,7 +436,7 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
             image_data = io.get_guide_images(night, expid, rawdir)
             web_guideimage.write_guide_image_html(image_data, htmlfile, night, expid)
             print('Wrote {}'.format(htmlfile))
-        except FileNotFoundError or OSError:
+        except (FileNotFoundError, OSError, IOError):
             print('Unable to find guide data, not plotting guide image plots')
 
     #- regardless of if logdir or preprocdir, identifying failed qprocs by comparing


### PR DESCRIPTION
Updated run.py to handle OSError resulting from an exposure having missing guide-rois-*.fits files.

<img width="1049" alt="Screen Shot 2020-07-09 at 5 26 37 PM" src="https://user-images.githubusercontent.com/47259815/87092402-5aacf500-c209-11ea-8346-d76cc522fcdd.png">
