### PR TITLE
fixed amp axis labels

### DIFF
--- a/py/nightwatch/plots/amp.py
+++ b/py/nightwatch/plots/amp.py
@@ -6,7 +6,7 @@ from bokeh.models.tickers import FixedTicker
 from bokeh.models.ranges import FactorRange
 from bokeh.models import (
     LinearColorMapper, ColorBar, ColumnDataSource, OpenURL,
-    NumeralTickFormatter,
+    NumeralTickFormatter, AdaptiveTicker,
     TapTool, Div, HoverTool, Range1d, BoxAnnotation, Whisker, Band,
     ResetTool, BoxZoomTool, OpenURL)
 from bokeh.models.callbacks import CustomJS
@@ -277,7 +277,17 @@ def plot_amp_qa(data, name, lower=None, upper=None, amp_keys=None, title=None, p
         if cam == 'Z':
             fig = plot_amp_cam_qa(data, name, cam, labels, title, lower=lower, upper=upper, amp_keys=amp_keys, plot_height=plot_height, plot_width=plot_width, ymin=ymin[2], ymax=ymax[2])
             
-        fig.yaxis.formatter = NumeralTickFormatter(format='a')
+        
+        if name == "BIAS":
+            fig.yaxis.ticker = AdaptiveTicker(base=10, desired_num_ticks=5, 
+                                              mantissas=np.arange(1, 5.5, 0.5), 
+                                              min_interval=1)
+            fig.yaxis.formatter = NumeralTickFormatter(format='e')
+        else:
+            fig.yaxis.ticker = AdaptiveTicker(base=10, desired_num_ticks=5, 
+                                              mantissas=np.arange(1, 5.5, 0.5), 
+                                              min_interval=1)
+            fig.yaxis.formatter = NumeralTickFormatter(format='a')
         figs.append(fig)
     
     # x-axis labels for spectrograph 0-9 and amplifier A-D


### PR DESCRIPTION
Integer labels for each per-amp plot- no more rounding issues that cause duplicate labels.

<img width="738" alt="Screen Shot 2020-07-09 at 9 53 57 PM" src="https://user-images.githubusercontent.com/47259815/87107833-cc4b6a00-c22e-11ea-8b96-c4f3fa079820.png">

<img width="738" alt="Screen Shot 2020-07-09 at 9 54 09 PM" src="https://user-images.githubusercontent.com/47259815/87107837-ce152d80-c22e-11ea-91f3-6b8dae2c5aa3.png">

<img width="736" alt="Screen Shot 2020-07-09 at 9 54 17 PM" src="https://user-images.githubusercontent.com/47259815/87107840-cf465a80-c22e-11ea-960f-402cd1c3aa76.png">
