### PR TITLE
Guide image rotation

### DIFF
--- a/py/nightwatch/io.py
+++ b/py/nightwatch/io.py
@@ -135,7 +135,7 @@ def get_guide_data(night, expid, basedir):
     else:
         raise FileNotFoundError('centroids-{expid:08d}.json not found'.format(expid=expid))
     
-def get_guide_images(night, expid, basedir, rot=False):
+def get_guide_images(night, expid, basedir): #, rot=False):
     '''Given a night and exposure, return file containing raw guide images.
     Args:
         night: int
@@ -151,8 +151,8 @@ def get_guide_images(night, expid, basedir, rot=False):
     else:
         image_data = dict()
 
-        gfa_file = os.path.expandvars('$DESIMODEL/data/focalplane/gfa.ecsv')
-        rotdict = rot_dict(gfa_file)
+#         gfa_file = os.path.expandvars('$DESIMODEL/data/focalplane/gfa.ecsv')
+#         rotdict = rot_dict(gfa_file)
 
         for cam in [0, 2, 3, 5, 7, 8]:
             name0 = 'GUIDE{cam}_{star}'.format(cam=cam, star=0)
@@ -161,12 +161,12 @@ def get_guide_images(night, expid, basedir, rot=False):
             name3 = 'GUIDE{cam}_{star}'.format(cam=cam, star=3)
             #name = 'GUIDE{cam}'.format(cam=cam)
 
-            angle = rotdict[str(cam)]
+            #angle = rotdict[str(cam)]
 
             try:
                 data = fits.getdata(infile, extname=name0)
-                if rot == True:
-                    data = rotate(data, angle, axes=(1, 2), reshape=False, mode='nearest')
+#                 if rot == True:
+#                     data = rotate(data, angle, axes=(1, 2), reshape=False, mode='nearest')
                 image_dict = dict()
                 for idx in range(len(data)):
                     image_dict[idx] = data[idx]
@@ -175,8 +175,8 @@ def get_guide_images(night, expid, basedir, rot=False):
                 print('no images for {name}'.format(name=name0))
             try:
                 data = fits.getdata(infile, extname=name1)
-                if rot == True:
-                    data = rotate(data, angle, axes=(1, 2), reshape=False, mode='nearest')
+#                 if rot == True:
+#                     data = rotate(data, angle, axes=(1, 2), reshape=False, mode='nearest')
                 image_dict = dict()
                 for idx in range(len(data)):
                     image_dict[idx] = data[idx]
@@ -185,8 +185,8 @@ def get_guide_images(night, expid, basedir, rot=False):
                 print('no images for {name}'.format(name=name1))
             try:
                 data = fits.getdata(infile, extname=name2)
-                if rot == True:
-                    data = rotate(data, angle, axes=(1, 2), reshape=False, mode='nearest')
+#                 if rot == True:
+#                     data = rotate(data, angle, axes=(1, 2), reshape=False, mode='nearest')
                 image_dict = dict()
                 for idx in range(len(data)):
                     image_dict[idx] = data[idx]
@@ -195,8 +195,8 @@ def get_guide_images(night, expid, basedir, rot=False):
                 print('no images for {name}'.format(name=name2))
             try:
                 data = fits.getdata(infile, extname=name3)
-                if rot == True:
-                    data = rotate(data, angle, axes=(1, 2), reshape=False, mode='nearest')
+#                 if rot == True:
+#                     data = rotate(data, angle, axes=(1, 2), reshape=False, mode='nearest')
                 image_dict = dict()
                 for idx in range(len(data)):
                     image_dict[idx] = data[idx]

--- a/py/nightwatch/plots/guideimage.py
+++ b/py/nightwatch/plots/guideimage.py
@@ -54,7 +54,7 @@ def rotate_guide_images(image_data, rotdict):
         data = image_data[key]
         ims = dict()
         for idx in data.keys():
-            zmin = np.percentile(data[idx], 10)
+            zmin = np.percentile(data[idx], 5)
             im = rotate(data[idx], angle, reshape=False, mode='constant', cval=zmin)
             ims[idx] = im
         images_rotated[key] = ims

--- a/py/nightwatch/webpages/templates/guideimage.html
+++ b/py/nightwatch/webpages/templates/guideimage.html
@@ -2,37 +2,16 @@
 {% block body %}
 
 <style>
-label {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  text-align: right;
-  width: 400px;
-  line-height: 26px;
-  margin-bottom: 10px;
-}
-
-input {
-  height: 20px;
-  flex: 0 0 200px;
-  margin-left: 10px;
-}
-
-table {
-  border-collapse: collapse;
-}
-
 .container{
   display: flex;
-}
-.flex-item{
-  flex-grow: 1;
 }
 </style>
 
 <header>
   Guide Images
 </header>
+
+<div>The GFA images are rotated so that each is aligned with the global focal plane XY coordinate system.</div>
 
 <div class="container">
 


### PR DESCRIPTION
Thought this was merged, but apparently I never opened a pull request... oops. Here's how this modifies the guide images:

<img width="1388" alt="Screen Shot 2020-07-17 at 12 17 42 PM" src="https://user-images.githubusercontent.com/47259815/87808350-8e020c00-c827-11ea-9251-da2e115f14b8.png">

The edge pixels that are left empty by the rotation of the images are filled in with an approximation of the background color (the 5th percentile of pixel values).