### PR TITLE
placeholder html for missing plots

### DIFF
--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -369,6 +369,7 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
     from nightwatch.webpages import lastexp as web_lastexp
     from nightwatch.webpages import guide as web_guide
     from nightwatch.webpages import guideimage as web_guideimage
+    from nightwatch.webpages import placeholder as web_placeholder
     from . import io
 
     log = desiutil.log.get_logger()
@@ -398,18 +399,27 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
         pc = web_amp.write_amp_html(htmlfile, qadata['PER_AMP'], header)
 #         plot_components.update(pc)
         print('Wrote {}'.format(htmlfile))
+    else:
+        htmlfile = '{}/qa-amp-{:08d}.html'.format(expdir, expid)
+        pc = web_placeholder.write_placeholder_html(htmlfile, header, "PER_AMP")
 
     if 'PER_CAMFIBER' in qadata:
         htmlfile = '{}/qa-camfiber-{:08d}.html'.format(expdir, expid)
         pc = web_camfiber.write_camfiber_html(htmlfile, qadata['PER_CAMFIBER'], header)
 #         plot_components.update(pc)
         print('Wrote {}'.format(htmlfile))
+    else:
+        htmlfile = '{}/qa-camfiber-{:08d}.html'.format(expdir, expid)
+        pc = web_placeholder.write_placeholder_html(htmlfile, header, "PER_CAMFIBER")
 
     if 'PER_CAMERA' in qadata:
         htmlfile = '{}/qa-camera-{:08d}.html'.format(expdir, expid)
         pc = web_camera.write_camera_html(htmlfile, qadata['PER_CAMERA'], header)
 #         plot_components.update(pc)
         print('Wrote {}'.format(htmlfile))
+    else:
+        htmlfile = '{}/qa-camera-{:08d}.html'.format(expdir, expid)
+        pc = web_placeholder.write_placeholder_html(htmlfile, header, "PER_CAMERA")
 
     htmlfile = '{}/qa-summary-{:08d}.html'.format(expdir, expid)
     web_summary.write_summary_html(htmlfile, qadata, preprocdir)
@@ -429,6 +439,8 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
             print('Wrote {}'.format(htmlfile))
         except (FileNotFoundError, OSError, IOError):
             print('Unable to find guide data, not plotting guide plots')
+            htmlfile = '{}/qa-guide-{:08d}.html'.format(expdir, expid)
+            pc = web_placeholder.write_placeholder_html(htmlfile, header, "GUIDING")
         
         #- plot guide image movies
         try:
@@ -438,6 +450,8 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
             print('Wrote {}'.format(htmlfile))
         except (FileNotFoundError, OSError, IOError):
             print('Unable to find guide data, not plotting guide image plots')
+            htmlfile = '{expdir}/guide-image-{expid:08d}.html'.format(expdir=expdir, expid=expid)
+            pc = web_placeholder.write_placeholder_html(htmlfile, header, "GUIDE_IMAGES")
 
     #- regardless of if logdir or preprocdir, identifying failed qprocs by comparing
     #- generated preproc files to generated logfiles

--- a/py/nightwatch/webpages/placeholder.py
+++ b/py/nightwatch/webpages/placeholder.py
@@ -2,6 +2,13 @@ import jinja2
 import bokeh
 
 def write_placeholder_html(outfile, header, attr):
+    '''Writes placeholder page for missing plots.
+    Args:
+        outfile: path to write html file to (str)
+        header: header data for the exposure (night, expid, exptime, etc)
+        attr: the type of missing plot (str); like PER_AMP, PER_CAMERA, etc.
+   Returns html components.
+        '''
     
     night = header['NIGHT']
     expid = header['EXPID']

--- a/py/nightwatch/webpages/placeholder.py
+++ b/py/nightwatch/webpages/placeholder.py
@@ -1,0 +1,41 @@
+import jinja2
+import bokeh
+
+def write_placeholder_html(outfile, header, attr):
+    
+    night = header['NIGHT']
+    expid = header['EXPID']
+    
+    if 'OBSTYPE' in header :
+        obstype = header['OBSTYPE'].rstrip().upper()
+    else :
+        log.warning('Use FLAVOR instead of missing OBSTYPE')
+        obstype = header['FLAVOR'].rstrip().upper()
+    if "PROGRAM" not in header :
+        program = "no program in header!"
+    else :
+        program = header['PROGRAM'].rstrip()
+    
+    exptime = header['EXPTIME']
+    
+    env = jinja2.Environment(
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+    )
+    template = env.get_template('placeholder.html')
+
+    html_components = dict(
+        bokeh_version=bokeh.__version__, exptime='{:.1f}'.format(exptime),
+        night=night, expid=expid, zexpid='{:08d}'.format(expid),
+        obstype=obstype, program=program, qatype=attr,
+        num_dirs=2,
+    )
+    
+    html = template.render(**html_components)
+
+    #- Write HTML text to the output file
+    with open(outfile, 'w') as fx:
+        fx.write(html)
+
+    return html_components
+
+    

--- a/py/nightwatch/webpages/templates/placeholder.html
+++ b/py/nightwatch/webpages/templates/placeholder.html
@@ -1,0 +1,5 @@
+{% extends "qabase.html" %}
+
+{% block body %}
+<div>No {{ qatype }} plots for exposure {{ expid }}.</div>
+{% endblock %}


### PR DESCRIPTION
I thought it might be better for navigation between exposures to have a placeholder html file for pages without plots rather than a greyed out link. It's also a little simpler than passing information about which QA metrics don't apply to all of the different html templates.

<img width="1394" alt="Screen Shot 2020-07-17 at 12 38 00 PM" src="https://user-images.githubusercontent.com/47259815/87810042-5ba5de00-c82a-11ea-992f-6291607c6c5e.png">
