### PR TITLE
Parallelize qa/amp.py

### DIFF
--- a/py/nightwatch/io.py
+++ b/py/nightwatch/io.py
@@ -163,7 +163,7 @@ def get_guide_images(night, expid, basedir): #, rot=False):
                 for idx in range(len(data)):
                     image_dict[idx] = data[idx]
                 image_data[name0] = image_dict
-            except IOError:
+            except (IOError, KeyError):
                 print('no images for {name}'.format(name=name0))
             try:
                 data = fits.getdata(infile, extname=name1)
@@ -171,7 +171,7 @@ def get_guide_images(night, expid, basedir): #, rot=False):
                 for idx in range(len(data)):
                     image_dict[idx] = data[idx]
                 image_data[name1] = image_dict
-            except IOError:
+            except (IOError, KeyError):
                 print('no images for {name}'.format(name=name1))
             try:
                 data = fits.getdata(infile, extname=name2)
@@ -179,7 +179,7 @@ def get_guide_images(night, expid, basedir): #, rot=False):
                 for idx in range(len(data)):
                     image_dict[idx] = data[idx]
                 image_data[name2] = image_dict
-            except IOError:
+            except (IOError, KeyError):
                 print('no images for {name}'.format(name=name2))
             try:
                 data = fits.getdata(infile, extname=name3)
@@ -187,7 +187,7 @@ def get_guide_images(night, expid, basedir): #, rot=False):
                 for idx in range(len(data)):
                     image_dict[idx] = data[idx]
                 image_data[name3] = image_dict
-            except IOError:
+            except (IOError, KeyError):
                 print('no images for {name}'.format(name=name3))
 
     return image_data

--- a/py/nightwatch/plots/amp.py
+++ b/py/nightwatch/plots/amp.py
@@ -66,7 +66,7 @@ def get_amp_size(data, lower_err, lower, upper, upper_err):
     return sizes
 
 def isolate_spec_lines(data_locs, data):
-    '''function to generate isolated data sets so that each spectrograph has an isolated line. Data must be sorted by amp.
+    '''function to generate isolated data sets so that each spectrograph has an isolated line.
     Inputs:
         data_locs: list of (spec, amp) pairs
         data: the metric data to be plotted (array)

--- a/py/nightwatch/plots/amp.py
+++ b/py/nightwatch/plots/amp.py
@@ -66,7 +66,7 @@ def get_amp_size(data, lower_err, lower, upper, upper_err):
     return sizes
 
 def isolate_spec_lines(data_locs, data):
-    '''function to generate isolated data sets so that each spectrograph has an isolated line
+    '''function to generate isolated data sets so that each spectrograph has an isolated line. Data must be sorted by amp.
     Inputs:
         data_locs: list of (spec, amp) pairs
         data: the metric data to be plotted (array)

--- a/py/nightwatch/qa/amp.py
+++ b/py/nightwatch/qa/amp.py
@@ -60,7 +60,10 @@ class QAAmp(QA):
         return num_cosmics
 
     def run(self, indir):
-        '''TODO: document'''
+        '''Generates table of PER_AMP qa metrics (READNOISE, BIAS, COSMICS_RATE).
+        Args:
+            indir: path to directory containing preproc-*.fits files for the given exposure
+        Returns an astropy Table object.'''
         infiles = glob.glob(os.path.join(indir, 'preproc-*.fits'))
         results = list()
         argslist = [(self, infile, amp) for infile in infiles for amp in ['A', 'B', 'C', 'D']]
@@ -82,7 +85,11 @@ class QAAmp(QA):
         return table
            
 def get_dico(self, filename, amp):
-    '''docstring'''
+    '''Function to generate per amp metrics given a preproc file to analyze, and a specific amp.
+    Args:
+        filename: path to preproc file (str)
+        amp: name of amp to analyze (str), either A, B, C, or D
+    Returns an OrderedDict object.'''
     
     hdr = fitsio.read_header(filename, 'IMAGE') #- for readnoise, bias
     mask = fitsio.read(filename, 'MASK')        #- for cosmics

--- a/py/nightwatch/webpages/amp.py
+++ b/py/nightwatch/webpages/amp.py
@@ -21,6 +21,7 @@ def write_amp_html(outfile, data, header):
     Returns:
         html_components dict with keys 'script', 'div' from bokeh
     '''
+    
     log = get_logger() 
     night = header['NIGHT']
     expid = header['EXPID']


### PR DESCRIPTION
Like PR #161 and PR #159, addresses issue #32, to parallelize QA calculations that allow it. Speeds up qa/amp.py processing by around 3x.