### PR TITLE
Fix XSS vulnerability in nightwatch Spin service

### DIFF
--- a/py/nightwatch/webpages/amp.py
+++ b/py/nightwatch/webpages/amp.py
@@ -36,8 +36,11 @@ def write_amp_html(outfile, data, header):
         program = header['PROGRAM'].rstrip()
     exptime = header['EXPTIME']
 
-    env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+      env = jinja2.Environment(
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('amp.html')
 

--- a/py/nightwatch/webpages/camera.py
+++ b/py/nightwatch/webpages/camera.py
@@ -37,7 +37,10 @@ def write_camera_html(outfile, data, header):
     exptime = header['EXPTIME']
 
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('camera.html')
 

--- a/py/nightwatch/webpages/camfiber.py
+++ b/py/nightwatch/webpages/camfiber.py
@@ -42,7 +42,10 @@ def write_camfiber_html(outfile, data, header):
     
     #- Sets environment to get get templates
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
 
     #- FIBERNUM PLOTS (default camfiber page)

--- a/py/nightwatch/webpages/guide.py
+++ b/py/nightwatch/webpages/guide.py
@@ -33,7 +33,10 @@ def write_guide_html(outfile, header, guidedata):
     exptime = header['EXPTIME']
 
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('guide.html')
 

--- a/py/nightwatch/webpages/guideimage.py
+++ b/py/nightwatch/webpages/guideimage.py
@@ -13,7 +13,10 @@ def write_guide_image_html(image_data, outfile, night, expid):
     Returns html components.'''
     
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     
     zexpid = '{expid:08d}'.format(expid=expid)

--- a/py/nightwatch/webpages/lastexp.py
+++ b/py/nightwatch/webpages/lastexp.py
@@ -40,7 +40,10 @@ def write_lastexp_html(outfile, qadata, qprocdir):
                 )
 
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('lastexp.html')
 

--- a/py/nightwatch/webpages/nightlyqa.py
+++ b/py/nightwatch/webpages/nightlyqa.py
@@ -146,7 +146,10 @@ def get_nightlyqa_html(night, exposures, fine_data, tiles, outdir, link_dict, he
         html_components['HIST'] = dict(script=script, div=div)
     
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     
     template = env.get_template('nightlyqa.html')

--- a/py/nightwatch/webpages/plotimage.py
+++ b/py/nightwatch/webpages/plotimage.py
@@ -14,7 +14,10 @@ def write_image_html(input, output, downsample, night):
     '''
 
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('preproc.html')
 
@@ -57,7 +60,10 @@ def write_preproc_table_html(input_dir, night, expid, downsample, output):
         output: write html file here
     '''
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('preproc.html')
 

--- a/py/nightwatch/webpages/spectra.py
+++ b/py/nightwatch/webpages/spectra.py
@@ -42,7 +42,10 @@ def get_spectra_html(data, night, expid, view, frame, downsample_str, select_str
         frame = "qframe"
 
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('spectra.html')
 

--- a/py/nightwatch/webpages/summary.py
+++ b/py/nightwatch/webpages/summary.py
@@ -124,7 +124,10 @@ def write_summary_html(outfile, qadata, qprocdir):
 #     update_camfib_pc(plot_components, qadata)
 
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('summary.html')
 
@@ -155,7 +158,10 @@ def write_logtable_html(outfile, logdir, night, expid, available=None, error_col
         None
     """
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('logfile.html')
 
@@ -201,7 +207,10 @@ def write_logfile_html(input, output, night):
     """
 
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('logfile.html')
 

--- a/py/nightwatch/webpages/summaryqa.py
+++ b/py/nightwatch/webpages/summaryqa.py
@@ -12,7 +12,10 @@ def get_summaryqa_html(exposures, fine_data, tiles, outdir, height=250, width=25
     '''outdir: same as directory where nightwatch files are generated. will be created in a new surveyqa subdirectory.'''
     
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     
     template = env.get_template('summaryqa.html')

--- a/py/nightwatch/webpages/tables.py
+++ b/py/nightwatch/webpages/tables.py
@@ -22,8 +22,11 @@ def write_nights_table(outfile, exposures):
         exposures: table with columns NIGHT, EXPID
     Returns: HTML file written to outfile path
     """    
-    env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+   env = jinja2.Environment(
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('nights.html')
 
@@ -160,7 +163,10 @@ def write_exposures_tables(indir, outdir, exposures, nights=None):
 
     log = desiutil.log.get_logger()
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('exposures.html')
 

--- a/py/nightwatch/webpages/thresholds.py
+++ b/py/nightwatch/webpages/thresholds.py
@@ -20,7 +20,10 @@ def write_threshold_html(outfile, outdir, datadir, start_date, end_date):
     '''
     
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('thresholds.html')
 

--- a/py/nightwatch/webpages/timeseries.py
+++ b/py/nightwatch/webpages/timeseries.py
@@ -18,7 +18,10 @@ def generate_timeseries_html(data, start_date, end_date, hdu, attribute, dropdow
     '''
 
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates')
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True, 
+                                     default=True,
     )
     template = env.get_template('timeseries.html')
 


### PR DESCRIPTION
Addresses security issue with the Nightwatch web app running on Spin at NERSC:

<img width="690" alt="Screen Shot 2020-08-06 at 12 54 27 PM" src="https://user-images.githubusercontent.com/47259815/89559667-fcf9d180-d7e3-11ea-9044-07b5ecf8f90b.png">

Now all jinja2 templates are configured to auto-escape any user input or attributes so any potentially malicious code is sanitized.