### PR TITLE
Plot scaling

### DIFF
--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -7,7 +7,6 @@ import bokeh
 import bokeh.plotting as bk
 import bokeh.palettes as bp
 from bokeh.models import TapTool, OpenURL
-from bokeh.models import ColumnDataSource, CDSView, BooleanFilter
 
 from ..plots.fiber import plot_fibers_focalplane, plot_fibernums
 # from ..plots.core import get_colors
@@ -66,8 +65,8 @@ def plot_camfib_focalplane(cds, attribute, cameras, percentiles={},
 
         # adjusts for outliers on the scale of the camera
 
-        booleans_metric = np.char.upper(np.array(cds.data['CAM']).astype(str)) == c.upper()
-        cam_metric = metric[booleans_metric]
+        in_cam = np.char.upper(np.array(cds.data['CAM']).astype(str)) == c.upper()
+        cam_metric = metric[in_cam]
 
 
         pmin, pmax = np.percentile(cam_metric, (2.5, 97.5))

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -38,12 +38,7 @@ def plot_camfib_focalplane(cds, attribute, cameras, percentiles={},
 
     metric = np.array(cds.data.get(attribute), copy=True)
 
-    #- adjusts for outliers on the full scale
-    #- change back to (2.5, 97.5) for the middle 95% for real data...?
-    #pmin, pmax = np.percentile(metric, (2.5, 97.5))
 
-    #- common scale for all histograms for this metric
-    #hist_x_range = (pmin * 0.99, pmax * 1.01)
 
     #- for hover tool
     attr_formatted_str = "@" + attribute + '{(0.00 a)}'
@@ -67,18 +62,15 @@ def plot_camfib_focalplane(cds, attribute, cameras, percentiles={},
             fig_x_range = figs_list[0].x_range
             fig_y_range = figs_list[0].y_range
 
-        #if i == (len(cameras) - 1):
-        #    colorbar = True
-        #else:
-        #    colorbar = False
+        colorbar = True
+
+        # adjusts for outliers on the scale of the camera
 
         booleans_metric = np.char.upper(np.array(cds.data['CAM']).astype(str)) == c.upper()
         cam_metric = metric[booleans_metric]
 
 
         pmin, pmax = np.percentile(cam_metric, (2.5, 97.5))
-
-        colorbar = True
 
         hist_x_range = (pmin * 0.99, pmax * 1.01)
 
@@ -121,12 +113,7 @@ def plot_camfib_fot(cds, attribute, cameras, percentiles={},
 
     metric = np.array(cds.data.get(attribute), copy=True)
 
-    #- adjusts for outliers on the full scale
-    #- change back to (2.5, 97.5) for the middle 95% for real data...?
-    pmin, pmax = np.percentile(metric, (2.5, 97.5))
 
-    #- common scale for all histograms for this metric
-    hist_x_range = (pmin * 0.99, pmax * 1.01)
 
     #- for hover tool
     attr_formatted_str = "@" + attribute + '{(0.00 a)}'
@@ -149,8 +136,10 @@ def plot_camfib_fot(cds, attribute, cameras, percentiles={},
             fig_x_range = figs_list[0].x_range
             fig_y_range = figs_list[0].y_range
 
-        booleans_metric = np.char.upper(np.array(cds.data['CAM']).astype(str)) == c.upper()
-        cam_metric = metric[booleans_metric]
+        # adjusts for outliers on the scale of the camera
+
+        in_cam = np.char.upper(np.array(cds.data['CAM']).astype(str)) == c.upper()
+        cam_metric = metric[in_cam]
 
 
         pmin, pmax = np.percentile(cam_metric, (2.5, 97.5))
@@ -181,7 +170,6 @@ def plot_camfib_posacc(pcd,attribute,percentiles={},
     metric = np.array(pcd.data.get(attribute), copy=True)
     metric = metric[np.where(metric>0)] #removed nan values
     pmin, pmax = np.percentile(metric, (2.5, 97.5))
-    #hist_x_range = (pmin * 0.99, pmax * 1.01)
 
     if attribute == 'BLIND':
         title = "Max Blind Move: {:.2f}um".format(np.max(metric))
@@ -242,10 +230,6 @@ def plot_per_fibernum(cds, attribute, cameras, titles={},
         return
 
     metric = np.array(cds.data.get(attribute), copy=True)
-
-    #- adjusts for outliers on the full scale
-    #- change back to (2.5, 97.5) for the middle 95% for real data...?
-    pmin, pmax = np.percentile(metric, (2.5, 97.5))
 
     #- for hover tool
     attr_formatted_str = "@" + attribute + '{(0.00 a)}'

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -7,6 +7,7 @@ import bokeh
 import bokeh.plotting as bk
 import bokeh.palettes as bp
 from bokeh.models import TapTool, OpenURL
+from bokeh.models import ColumnDataSource, CDSView, BooleanFilter
 
 from ..plots.fiber import plot_fibers_focalplane, plot_fibernums
 # from ..plots.core import get_colors
@@ -39,10 +40,10 @@ def plot_camfib_focalplane(cds, attribute, cameras, percentiles={},
 
     #- adjusts for outliers on the full scale
     #- change back to (2.5, 97.5) for the middle 95% for real data...?
-    pmin, pmax = np.percentile(metric, (0, 95))
+    #pmin, pmax = np.percentile(metric, (2.5, 97.5))
 
     #- common scale for all histograms for this metric
-    hist_x_range = (pmin * 0.99, pmax * 1.01)
+    #hist_x_range = (pmin * 0.99, pmax * 1.01)
 
     #- for hover tool
     attr_formatted_str = "@" + attribute + '{(0.00 a)}'
@@ -66,10 +67,20 @@ def plot_camfib_focalplane(cds, attribute, cameras, percentiles={},
             fig_x_range = figs_list[0].x_range
             fig_y_range = figs_list[0].y_range
 
-        if i == (len(cameras) - 1):
-            colorbar = True
-        else:
-            colorbar = False
+        #if i == (len(cameras) - 1):
+        #    colorbar = True
+        #else:
+        #    colorbar = False
+
+        booleans_metric = np.char.upper(np.array(cds.data['CAM']).astype(str)) == c.upper()
+        cam_metric = metric[booleans_metric]
+
+
+        pmin, pmax = np.percentile(cam_metric, (2.5, 97.5))
+
+        colorbar = True
+
+        hist_x_range = (pmin * 0.99, pmax * 1.01)
 
         fig, hfig = plot_fibers_focalplane(cds, attribute, cam=c,
                         percentile=percentiles.get(c),
@@ -112,7 +123,7 @@ def plot_camfib_fot(cds, attribute, cameras, percentiles={},
 
     #- adjusts for outliers on the full scale
     #- change back to (2.5, 97.5) for the middle 95% for real data...?
-    pmin, pmax = np.percentile(metric, (0, 95))
+    pmin, pmax = np.percentile(metric, (2.5, 97.5))
 
     #- common scale for all histograms for this metric
     hist_x_range = (pmin * 0.99, pmax * 1.01)
@@ -138,6 +149,16 @@ def plot_camfib_fot(cds, attribute, cameras, percentiles={},
             fig_x_range = figs_list[0].x_range
             fig_y_range = figs_list[0].y_range
 
+        booleans_metric = np.char.upper(np.array(cds.data['CAM']).astype(str)) == c.upper()
+        cam_metric = metric[booleans_metric]
+
+
+        pmin, pmax = np.percentile(cam_metric, (2.5, 97.5))
+
+        colorbar = True
+
+        hist_x_range = (pmin * 0.99, pmax * 1.01)
+
         fig, hfig = plot_fibers_focalplane(cds, attribute, cam=c,
                         percentile=percentiles.get(c),
                         zmin=zmins.get(c), zmax=zmaxs.get(c),
@@ -159,7 +180,7 @@ def plot_camfib_posacc(pcd,attribute,percentiles={},
     hfigs_list = []
     metric = np.array(pcd.data.get(attribute), copy=True)
     metric = metric[np.where(metric>0)] #removed nan values
-    pmin, pmax = np.percentile(metric, (0, 95))
+    pmin, pmax = np.percentile(metric, (2.5, 97.5))
     #hist_x_range = (pmin * 0.99, pmax * 1.01)
 
     if attribute == 'BLIND':
@@ -224,7 +245,7 @@ def plot_per_fibernum(cds, attribute, cameras, titles={},
 
     #- adjusts for outliers on the full scale
     #- change back to (2.5, 97.5) for the middle 95% for real data...?
-    pmin, pmax = np.percentile(metric, (0, 95))
+    pmin, pmax = np.percentile(metric, (2.5, 97.5))
 
     #- for hover tool
     attr_formatted_str = "@" + attribute + '{(0.00 a)}'

--- a/py/nightwatch/plots/fiber.py
+++ b/py/nightwatch/plots/fiber.py
@@ -1,7 +1,7 @@
 import numpy as np
 import jinja2
 import desimodel.io
-
+import scipy.stats
 import bokeh
 import bokeh.plotting as bk
 import bokeh.models
@@ -52,8 +52,12 @@ def plot_fibers_focalplane(source, name, cam='',
     '''
     full_metric =np.array(source.data.get(name), copy=True)
 
-    #- adjusts for outliers on the full scale
-    pmin_full, pmax_full = np.percentile(full_metric, (0, 95))
+    #- adjusts for outliers on each camera's scale
+
+    in_cam = np.char.upper(np.array(source.data['CAM']).astype(str)) == cam.upper()
+    cam_metric = full_metric[in_cam]
+
+    pmin_full, pmax_full = np.percentile(cam_metric, (2.5, 97.5))
 
     #- Generate colors for both plots
     if not palette:
@@ -135,9 +139,6 @@ def plot_fibers_focalplane(source, name, cam='',
     if not plot_hist:
         return fig, None
 
-    if not plot_hist:
-        return fig, None
-
     #- Histogram of values
     metric = full_metric[booleans_metric]
 
@@ -181,7 +182,7 @@ def plot_fibernums(source, name, cam='',
     #- Will that break when plotting fiber plots individually?
     full_metric = np.array(source.data.get(name), copy=True)
     #- adjusts for outliers on the full scale
-    pmin_full, pmax_full = np.percentile(full_metric, (0, 95))
+    pmin_full, pmax_full = np.percentile(full_metric, (2.5, 97.5))
 
     #- Fibernum scatter plot
     fig = bk.figure(width=width, height=height, title=title, tools=tools,

--- a/py/nightwatch/plots/fiber.py
+++ b/py/nightwatch/plots/fiber.py
@@ -1,7 +1,6 @@
 import numpy as np
 import jinja2
 import desimodel.io
-import scipy.stats
 import bokeh
 import bokeh.plotting as bk
 import bokeh.models

--- a/py/nightwatch/plots/fiber.py
+++ b/py/nightwatch/plots/fiber.py
@@ -1,6 +1,7 @@
 import numpy as np
 import jinja2
 import desimodel.io
+
 import bokeh
 import bokeh.plotting as bk
 import bokeh.models

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -210,7 +210,6 @@ def run_preproc(rawfile, outdir, ncpu=None, cameras=None):
     for camera in cameras:
         args = ['--infile', rawfile, '--outdir', outdir, '--cameras', camera]
         arglist.append(args)
-    print(arglist)
 
     ncpu = min(len(arglist), get_ncpu(ncpu))
 

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -210,6 +210,7 @@ def run_preproc(rawfile, outdir, ncpu=None, cameras=None):
     for camera in cameras:
         args = ['--infile', rawfile, '--outdir', outdir, '--cameras', camera]
         arglist.append(args)
+    print(arglist)
 
     ncpu = min(len(arglist), get_ncpu(ncpu))
 
@@ -503,7 +504,7 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
             pool.join()
             
         else:
-            for args in arglist:
+            for args in argslist:
                 web_plotimage.write_image_html(*args)
 
         #- plot preproc nav table

--- a/py/nightwatch/webpages/camfiber.py
+++ b/py/nightwatch/webpages/camfiber.py
@@ -32,7 +32,7 @@ def write_camfiber_html(outfile, data, header):
     ATTRIBUTES = ['INTEG_RAW_FLUX', 'MEDIAN_RAW_FLUX', 'MEDIAN_RAW_SNR', 'INTEG_CALIB_FLUX',
                  'MEDIAN_CALIB_FLUX', 'MEDIAN_CALIB_SNR']
     CAMERAS = ['B', 'R', 'Z']
-    PERCENTILES = {'B':(0, 95), 'R':(0, 95), 'Z':(0, 98)}
+    PERCENTILES = {'B':(2.5, 97.5), 'R':(2.5, 97.5), 'Z':(2.5, 97.5)}
     TITLES = {'INTEG_RAW_FLUX':'Integrated Raw Counts', 'MEDIAN_RAW_FLUX':'Median Raw Counts',
               'MEDIAN_RAW_SNR':'Median Raw S/N', 'INTEG_CALIB_FLUX':'Integrated Calibrated Flux',
               'MEDIAN_CALIB_FLUX':'Median Calibrated Flux', 'MEDIAN_CALIB_SNR':'Median Calibrated S/N',


### PR DESCRIPTION
Addresses issue #141 by adjusting the colorbar scale to middle 95% of values rather than lower 95% of values. 

Additionally, repurposes some camera selection code to make a colorbar for each camera to restore dynamic range to most plots. 

![MedianRawSN](https://user-images.githubusercontent.com/5750293/95523675-3e9e2880-099d-11eb-98fb-5f4b20df693f.PNG)

![MedianCalibSN](https://user-images.githubusercontent.com/5750293/95523684-46f66380-099d-11eb-9d90-e6331da38470.PNG)

These images are from exposure 29169, the dithering exposure referenced in the second half of the issue. I would have also grabbed the data to reproduce the other exposures' plots but NERSC is down. 

Probably in the future will need to create a dynamic range determination in case large numbers of pixels are saturated/hot/cold. This would be a good thing to add along with issue #125 which is going to add warnings for badly saturated CCDs. 


There was one minor duplicated piece of code that I removed in plot_fibers_focalplane.py

A major unrelated issue is that run.py tried to loop through "args in arglist" but only defined the term "arg*s*list." I didn't want to touch anything unrelated to the issue for my first foray into nightwatch, but the code literally wouldn't start running on my laptop without that change.




@sbailey @rstaten @rkehoe  - please review and provide comments. 