### PR TITLE
batch updates; no tempdir

### DIFF
--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -546,6 +546,7 @@ def write_tables(indir, outdir, expnights=None):
     
 
     log = desiutil.log.get_logger()
+    log.info(f'Tabulating exposures in {indir}')
 
     #- Hack: parse the directory structure to learn nights
     rows = list()

--- a/py/nightwatch/script.py
+++ b/py/nightwatch/script.py
@@ -309,7 +309,9 @@ def main_run(options=None):
         
     night, expid = io.get_night_expid(args.infile)
     rawdir = os.path.dirname(os.path.dirname(os.path.dirname(args.infile)))
-    
+
+    #- Using a tempdir sometimes is better, and sometimes is way worse;
+    #- turn off for now
     # with TempDirManager(args.outdir) as tempdir:
     tempdir = args.outdir
     if True:

--- a/py/nightwatch/webpages/tables.py
+++ b/py/nightwatch/webpages/tables.py
@@ -51,8 +51,11 @@ def write_nights_table(outfile, exposures):
             })
 
     html = template.render(nights=nights_sep)
-    with open(outfile, 'w') as fx:
+    tmpfile = outfile + '.tmp' + str(os.getpid())
+    with open(tmpfile, 'w') as fx:
         fx.write(html)
+
+    os.rename(tmpfile, outfile)
 
 def _write_night_links(outdir):
     all_files = os.listdir(outdir)
@@ -78,7 +81,8 @@ def _write_night_links(outdir):
         links[night] = dict(prev_n = prev_n, next_n = next_n)
 
     outfile = os.path.join(outdir, 'nightlinks.js')
-    with open(outfile, 'w') as fx:
+    tmpfile = outfile + '.tmp' + str(os.getpid())
+    with open(tmpfile, 'w') as fx:
         fx.write("""/*
 Returns night prev/next links as a string
 
@@ -89,6 +93,8 @@ The first and last exposure have prev/next as [null, null]
 */
 get_nightlinks({})
 """.format(json.dumps(links, indent=2)))
+
+    os.rename(tmpfile, outfile)
 
 
 def _write_expid_links(outdir, exposures, nights=None):
@@ -140,7 +146,8 @@ def _write_expid_links(outdir, exposures, nights=None):
     #- Only update explinks files for nights in the nights list
     for night in nights:
         outfile = os.path.join(outdir, str(night), 'explinks-{}.js'.format(night))
-        with open(outfile, 'w') as fx:
+        tmpfile = outfile + '.tmp' + str(os.getpid())
+        with open(tmpfile, 'w') as fx:
             fx.write("""/*
 Returns exposure prev/next links for this night as a nested dictionary
 
@@ -151,6 +158,8 @@ The first and last exposure have prev/next as [null, null]
 */
 get_explinks({})
 """.format(json.dumps(links[night], indent=2)))
+
+        os.rename(tmpfile, outfile)
 
 
 def write_exposures_tables(indir, outdir, exposures, nights=None):
@@ -246,8 +255,11 @@ def write_exposures_tables(indir, outdir, exposures, nights=None):
         html = template.render(night=night, exposures=explist, autoreload=True,
             staticdir='../static')
         outfile = os.path.join(outdir, str(night), 'exposures.html')
-        with open(outfile, 'w') as fx:
+        tmpfile = outfile + '.tmp' + str(os.getpid())
+        with open(tmpfile, 'w') as fx:
             fx.write(html)
+
+        os.rename(tmpfile, outfile)
 
     #- Update expid and night links only once at the end
     _write_expid_links(outdir, exposures, nights)


### PR DESCRIPTION
This PR makes several updates for running nightwatch at NERSC in prep for DESI restart:
  * update batch processing methodology `nightwatch monitor ... --batch`:
    * batch process qproc+qa+plots, not just the qproc step
    * submit jobs with `sbatch` instead of just spawning with `srun`, thus enabling processing multiple exposures in parallel if redrock gets behind (e.g. with a bunch of zeros or arcs showing up together)
    * result is that nightwatch can process a full night (20200315) in about 15 minutes using 12 realtime queue nodes
  * in some cases when writing outputs, write a temporary file first and then rename it to prevent partially written files and different jobs stepping on each other.  This could be done in more cases, but this PR has a start on that for some files.
  * stop using a node-local tempdir and then copy results to CFS; over the summer that seemed to help with speed, but in testing now the copying processes often get wedged and end up taking much longer.