### PR TITLE
pandas, bokeh, bytes, str

### DIFF
--- a/py/nightwatch/webpages/camfiber.py
+++ b/py/nightwatch/webpages/camfiber.py
@@ -185,6 +185,7 @@ def get_posacc_cd(header):
     fiberpos = Table(desimodel.io.load_fiberpos()).to_pandas()
     fiberpos.PETAL = fiberpos.PETAL.astype(int)
     fiberpos.DEVICE = fiberpos.DEVICE.astype(int)
+    fiberpos.DEVICE_TYPE = fiberpos.DEVICE_TYPE.astype(str)
     night = header['NIGHT']
     expid = header['EXPID']
     coordfile = '{}/{}/coordinates-{}.fits'.format(night, str(expid).zfill(8), str(expid).zfill(8))


### PR DESCRIPTION
Apparently bokeh/2.2.1 + pandas/1.1.1 is more sensitive to bytes vs. str than bokeh/2.1.1  pandas/1.0.5, which was causing it to get tripped up when the fiberpos fits file was read and had the DEVICE_TYPE column as bytes instead of str, eventually propagating to a json serialization exception.  This one-line change forces DEVICE_TYPE to str and everyone is happy again.  I'm not sure if the "fault" is with bokeh or pandas.

Side note: I hadn't noticed that pandas has slipped in as an explicit dependency for nightwatch, which I would prefer to avoid.  However, at this point just before restarting, I'm making the minimal changes necessary for it to work, and not doing unnecessary pandas surgery (which is still limited enough it wouldn't be too hard to update this in the future if needed).