### PR TITLE
added a missing logger call to placeholder

### DIFF
--- a/py/nightwatch/webpages/placeholder.py
+++ b/py/nightwatch/webpages/placeholder.py
@@ -1,6 +1,7 @@
 import jinja2
 from jinja2 import select_autoescape
 import bokeh
+from desiutil.log import get_logger
 
 def write_placeholder_html(outfile, header, attr):
     '''Writes placeholder page for missing plots.
@@ -10,6 +11,8 @@ def write_placeholder_html(outfile, header, attr):
         attr: the type of missing plot (str); like PER_AMP, PER_CAMERA, etc.
    Returns html components.
         '''
+
+    log=get_logger()
     
     night = header['NIGHT']
     expid = header['EXPID']


### PR DESCRIPTION
This is a minor change, but the issue completely breaks "nightwatch run" 

Just added a "get_logger" call to the start of placeholder.py since it tries to use the logger before it was called. 