### PR TITLE
fix random spectra plotting

### DIFF
--- a/py/nightwatch/plots/spectra.py
+++ b/py/nightwatch/plots/spectra.py
@@ -318,35 +318,35 @@ def plot_spectra_input(datadir, expid_num, frame, n, select_string, height=500, 
 
     fig=bk.figure(plot_height = height, plot_width = width)
 
-    for spectro, cam in zip(fibergroups, colors):
-#          rbz_none = [False]*len(fibergroups[spectro])
+    for spectro in fibergroups.keys():
+        for cam in colors:
+            framefile = os.path.join(datadir, expid,
+                    '{}-{}{}-{}.fits'.format(frame, cam.lower(), spectro, expid))
+            if not os.path.isfile(framefile):
+                print(f"WARNING: missing {framefile}")
+                continue
 
-#         for cam in colors:
-        framefile = os.path.join(datadir, expid, '{}-{}{}-{}.fits'.format(frame, cam.lower(), spectro, expid))
-        if not os.path.isfile(framefile):
-            continue
+            fibermap = fits.getdata(framefile, 'FIBERMAP')
 
-        fibermap = fits.getdata(framefile, 'FIBERMAP')
+            wavelength = fits.getdata(framefile, "WAVELENGTH")
+            flux = fits.getdata(framefile, "FLUX")
+            spectrofibers = fibergroups[spectro]
+            indexes = np.where(np.in1d(fibermap['FIBER'], spectrofibers))[0]
+            assert len(spectrofibers) == len(indexes)
 
-        wavelength = fits.getdata(framefile, "WAVELENGTH")
-        flux = fits.getdata(framefile, "FLUX")
-        spectrofibers = fibergroups[spectro]
-        indexes = np.where(np.in1d(fibermap['FIBER'], spectrofibers))[0]
-        assert len(spectrofibers) == len(indexes)
-
-        for i, ifiber in zip(indexes, spectrofibers):
-            dwavelength = downsample(wavelength[i], n)
-            dflux = downsample(flux[i], n)
-            length = len(dwavelength)
-            source = ColumnDataSource(data=dict(
-                        fiber = [ifiber]*length,
-                        cam = [cam]*length,
-                        wave = dwavelength,
-                        flux = dflux
-                    ))
-            flux_total += dflux
-            #print(str(i), file=sys.stderr)
-            fig.line("wave", "flux", source=source, alpha=0.5, color=colors[cam])
+            for i, ifiber in zip(indexes, spectrofibers):
+                dwavelength = downsample(wavelength[i], n)
+                dflux = downsample(flux[i], n)
+                length = len(dwavelength)
+                source = ColumnDataSource(data=dict(
+                            fiber = [ifiber]*length,
+                            cam = [cam]*length,
+                            wave = dwavelength,
+                            flux = dflux
+                        ))
+                flux_total += dflux
+                #print(str(i), file=sys.stderr)
+                fig.line("wave", "flux", source=source, alpha=0.5, color=colors[cam])
 
     # fig.add_layout(Title(text= "Downsample: {}".format(n), text_font_style="italic"), 'above')
     if len(missingfibers) > 0:


### PR DESCRIPTION
This PR fixes a bug in how random spectra are plotted.  The problem was this line:
```python
for spectro, cam in zip(fibergroups, colors):
```

`fibergroups` is a dictionary over spectrographs, while `colors` is a dictionary over B/R/Z.  zipping those resulted in plotting different spectrographs of fibers for each of B/R/Z, instead of plotting the same spectra across all of B/R/Z.  I found this by testing with only 2 spectrographs, and then `fibergroups` only had 2 entries, and then it never got around to plotting `Z`...

```
nightwatch run -i $DESI_SPECTRO_DATA/20200315/00055611/desi*.fits.fz     -o /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/fbatest/nightwatch     --cameras b1,r1,z1,b2,r2,z2
```

@jalasker could you review this?  Thanks.