### PR TITLE
make calendar writing faster

### DIFF
--- a/py/nightwatch/webpages/tables.py
+++ b/py/nightwatch/webpages/tables.py
@@ -15,12 +15,14 @@ import desiutil.log
 from .. import io
 from ..qa.status import get_status, Status
 
-def write_nights_table(outfile, exposures):
+def write_calendar(outfile, nights):
     """
     Writes nights calendar html file
+
     Args:
         outfile: output HTML file
-        exposures: table with columns NIGHT, EXPID
+        nights: dict-like nights[night] = number_of_exposures
+
     Returns: HTML file written to outfile path
     """    
     env = jinja2.Environment(
@@ -32,15 +34,9 @@ def write_nights_table(outfile, exposures):
     
     template = env.get_template('nights.html')
 
-
-    expo = Table(exposures)
-
-    # Count exposures per night
-    expcounter = Counter(expo["NIGHT"])
-
     # Split night YEARMMDD into YEAR, MM-1, DD
     nights_sep = list()
-    for night, numexp in sorted(expcounter.items()):
+    for night, numexp in sorted(nights.items()):
         night = str(night)
         nights_sep.append({
             "name" : night,


### PR DESCRIPTION
This PR fixes #128 by making the writing of the calendar faster.  Previously it was loading all of the qa-EXPID.fits files to build an exposure table to pass to the calendar writer, but the calendar writer was only using it to count the number of exposures per night.  This branch now only generates the full exposures table for the requested night(s), which is typically the current night, and separately counts exposures/night by counting directories on disk instead of actually reading all the files.

@jalasker if you have the time to review this on Weds that would be much appreciated; I'd like to get it in place before we resume spectrograph calibrations, since currently nightwatch gets pretty far behind due to all the unnecessary file reading.  I think I have tested it fairly well at NERSC, but I did trip on several "is night an int or a str" kinds of bugs, so additional independent testing would be appreciated if you can do it in time.

Note: #128 was previously partially fixed by an earlier PR which at least stopped *writing* the exposures table for every night for every new exposure.  This PR takes it one step further to minimize the amount of *reading* needed.

Other convenience options that came along for the ride:
  * adding --night and --expid options to "nightwatch run", which can be used instead of --infile
  * adding --nights option to "nightwatch tables" to only update the tables for the specified night(s), similar to "nightwatch run" and "nightwatch monitor" only updating the tables for the current night.