### PR TITLE
more robust handling of failed plotting

### DIFF
--- a/py/nightwatch/plots/core.py
+++ b/py/nightwatch/plots/core.py
@@ -66,10 +66,8 @@ def plot_histogram(metric, num_bins=50, width=250, height=80, x_range=None, titl
     #- Generate histogram colors
     if palette is not None:
         if not low:
-            print('new low')
             low = min(metric)
         if not high:
-            print('new high')
             high = max(metric)
         mapper = linear_cmap('centers', palette, low=low, high=high, nan_color='gray')
     else:

--- a/py/nightwatch/webpages/camfiber.py
+++ b/py/nightwatch/webpages/camfiber.py
@@ -192,6 +192,10 @@ def get_posacc_cd(header):
 
     if os.path.isfile(coordfile):
         df = Table(fitsio.read(coordfile)).to_pandas()
+        if 'OFFSET_0' not in df:
+            print(f'WARNING positioner offsets not in {coordfile}; not making positioner accuracy plots')
+            return None
+
         final_move = np.sort(fnmatch.filter(df.columns, 'OFFSET_*'))[-1]
         df = df.merge(fiberpos, how='left',left_on=['PETAL_LOC','DEVICE_LOC'], right_on=['PETAL','DEVICE'])
         df['BLIND'] = df['OFFSET_0']*1000

--- a/py/nightwatch/webpages/placeholder.py
+++ b/py/nightwatch/webpages/placeholder.py
@@ -3,14 +3,18 @@ from jinja2 import select_autoescape
 import bokeh
 from desiutil.log import get_logger
 
-def write_placeholder_html(outfile, header, attr):
+def write_placeholder_html(outfile, header, attr, message=None):
     '''Writes placeholder page for missing plots.
     Args:
         outfile: path to write html file to (str)
         header: header data for the exposure (night, expid, exptime, etc)
         attr: the type of missing plot (str); like PER_AMP, PER_CAMERA, etc.
-   Returns html components.
-        '''
+
+    Options:
+        message (str): optional message to include in placeholder file
+
+    Returns html components.
+    '''
 
     log=get_logger()
     
@@ -44,6 +48,8 @@ def write_placeholder_html(outfile, header, attr):
         obstype=obstype, program=program, qatype=attr,
         num_dirs=2,
     )
+    if message is not None:
+        html_components['message'] = message
     
     html = template.render(**html_components)
 

--- a/py/nightwatch/webpages/templates/placeholder.html
+++ b/py/nightwatch/webpages/templates/placeholder.html
@@ -2,4 +2,12 @@
 
 {% block body %}
 <div>No {{ qatype }} plots for exposure {{ expid }}.</div>
+
+{% if message %}
+<div><pre>
+{{ message }}
+</pre></div>
+{% endif %}
+
+
 {% endblock %}


### PR DESCRIPTION
This PR fixes #185 by providing more robust handling of plotting failures so that failure to make one plot type don't prevent making other plots.

More cleanup could be done in this regard, but it fixes the currently relevant problem of on-sky data taken without the positioner update loop, which results in coordinates files with only a small subset of the usual columns.  I'd like to merge and deploy this for tonight.

Tested with exposures 20201209/66641 and 20201206/66285.