### PR TITLE
plot robustness; handle coordinates files with and without FIBER column

### DIFF
--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -417,22 +417,13 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
         htmlfile = '{}/qa-amp-{:08d}.html'.format(expdir, expid)
         pc = web_placeholder.write_placeholder_html(htmlfile, header, "PER_AMP")
 
-    #- utility function to print tracebacks for failed plotting
-    def handle_failed_plot(htmlfile, header, qatype):
-        lines = traceback.format_exception(*sys.exc_info())
-        msg = f'ERROR generating {htmlfile}\n' + ''.join(lines)
-        print(msg)
-        print('Proceeding with making other plots')
-        pc = web_placeholder.write_placeholder_html(
-                htmlfile, header, "PER_CAMFIBER", message=msg)
-
     htmlfile = '{}/qa-camfiber-{:08d}.html'.format(expdir, expid)
     if 'PER_CAMFIBER' in qadata:
         try:
             pc = web_camfiber.write_camfiber_html(htmlfile, qadata['PER_CAMFIBER'], header)
             print('Wrote {}'.format(htmlfile))
         except Exception as err:
-            handle_failed_plot(htmlfile, header, "PER_CAMFIBER")
+            web_placeholder.handle_failed_plot(htmlfile, header, "PER_CAMFIBER")
     else:
         pc = web_placeholder.write_placeholder_html(htmlfile, header, "PER_CAMFIBER")
 
@@ -442,7 +433,7 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
             pc = web_camera.write_camera_html(htmlfile, qadata['PER_CAMERA'], header)
             print('Wrote {}'.format(htmlfile))
         except Exception as err:
-            handle_failed_plot(htmlfile, header, "PER_CAMERA")
+            web_placeholder.handle_failed_plot(htmlfile, header, "PER_CAMERA")
     else:
         pc = web_placeholder.write_placeholder_html(htmlfile, header, "PER_CAMERA")
 

--- a/py/nightwatch/webpages/placeholder.py
+++ b/py/nightwatch/webpages/placeholder.py
@@ -59,4 +59,25 @@ def write_placeholder_html(outfile, header, attr, message=None):
 
     return html_components
 
+#- utility function to print tracebacks for failed plotting
+def handle_failed_plot(htmlfile, header, qatype):
+    """
+    Write placeholder file with error traceback for a failed plot
+
+    Args:
+        htmlfile (str): filename to write
+        header (dict-like): header metadata (NIGHT, EXPID, EXPTIME, etc)
+        qatype (str): the type of missing plot, e.g. PER_AMP, PER_CAMERA, etc.
+
+    Returns bokeh plot components dict from func:`web_placeholder`
+    """
+    import sys
+    import traceback
+    lines = traceback.format_exception(*sys.exc_info())
+    msg = f'ERROR generating {htmlfile}\n' + ''.join(lines)
+    print(msg)
+    print('Proceeding with making other plots')
+    pc = write_placeholder_html(
+            htmlfile, header, "PER_CAMFIBER", message=msg)
+    return pc
     


### PR DESCRIPTION
This is a hotfix PR for night 20201220 where PER_CAMFIBER plots are failing.  The cause was a new "FIBER" column in platemaker coordinates files which was conflicting with the "FIBER" column in the fiberassign files.  Although these columns mean the same thing and it shouldn't be fundamentally problematic for coordinates files to have them too, pandas was silently "fixing" the name conflict when merging the two tables by giving them both unique names, resulting in no column being named "FIBER" for plotting...

This PR handles coordinates files with or without a FIBER column, and continues the work of PR #187 by ensuring that the failure to make one type of PER_CAMFIBER page doesn't block the ability write a different PER_CAMFIBER page.

For the record, the previous traceback before this fix:
```
Traceback (most recent call last):
  File "/software/datasystems/desiconda/20200924/code/nightwatch/master/py/nightwatch/run.py", line 432, in make_plots
    pc = web_camfiber.write_camfiber_html(htmlfile, qadata['PER_CAMFIBER'], header)
  File "/software/datasystems/desiconda/20200924/code/nightwatch/master/py/nightwatch/webpages/camfiber.py", line 66, in write_camfiber_html
    write_posacc_plots(data, pa_template, pa_outfile, header, ATTRIBUTES, CAMERAS, PERCENTILES, TITLESPERCAM, TOOLS)
  File "/software/datasystems/desiconda/20200924/code/nightwatch/master/py/nightwatch/webpages/camfiber.py", line 169, in write_posacc_plots
    figs_list,hfigs_list = plot_camfib_posacc(pcd, attr, percentiles=PERCENTILES,tools=TOOLS)
  File "/software/datasystems/desiconda/20200924/code/nightwatch/master/py/nightwatch/plots/camfiber.py", line 198, in plot_camfib_posacc
    fig, hfig = plot_fibers_focalplane(pcd, attribute,cam=c,
  File "/software/datasystems/desiconda/20200924/code/nightwatch/master/py/nightwatch/plots/fiber.py", line 92, in plot_fibers_focalplane
    fibers_measured = source.data['FIBER'][booleans_metric]
KeyError: 'FIBER'
```