### PR TITLE
Default calibrated spectra plots

### DIFF
--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -283,7 +283,11 @@ def plot_per_fibernum(cds, attribute, cameras, titles={},
                             )
 
         taptool = fig.select(type=TapTool)
-        taptool.callback = OpenURL(url="spectra/input/@FIBER/qframe/4x/")
+        #- Default to qcframe upon click, unless raw camfiber plot
+        if "RAW" in attribute:
+            taptool.callback = OpenURL(url="spectra/input/@FIBER/qframe/4x/")
+        else:
+            taptool.callback = OpenURL(url="spectra/input/@FIBER/qcframe/4x/")
         figs_list.append(fig)
         
     return figs_list

--- a/py/nightwatch/plots/fiber.py
+++ b/py/nightwatch/plots/fiber.py
@@ -224,6 +224,10 @@ def plot_fibernums(source, name, cam='',
     fig.yaxis.formatter = NumeralTickFormatter(format='0.0a')
 
     taptool = fig.select(type=TapTool)
-    taptool.callback = OpenURL(url="spectra/input/@FIBER/qframe/4x/")
+    #- Default to qcframe upon click, unless raw camfiber plot
+    if "RAW" in name:
+        taptool.callback = OpenURL(url="spectra/input/@FIBER/qframe/4x/")
+    else:
+        taptool.callback = OpenURL(url="spectra/input/@FIBER/qcframe/4x/")
 
     return fig

--- a/py/nightwatch/plots/fiber.py
+++ b/py/nightwatch/plots/fiber.py
@@ -123,7 +123,11 @@ def plot_fibers_focalplane(source, name, cam='',
     fig.yaxis.major_label_text_font_size = '0pt'
 
     taptool = fig.select(type=TapTool)
-    taptool.callback = OpenURL(url="spectra/input/@FIBER/qframe/4x/")
+    #- Default to qcframe upon click, unless raw camfiber plot
+    if "RAW" in name:
+        taptool.callback = OpenURL(url="spectra/input/@FIBER/qframe/4x/")
+    else:
+        taptool.callback = OpenURL(url="spectra/input/@FIBER/qcframe/4x/")
 
     #- Add colorbar
     if colorbar:
@@ -229,5 +233,5 @@ def plot_fibernums(source, name, cam='',
         taptool.callback = OpenURL(url="spectra/input/@FIBER/qframe/4x/")
     else:
         taptool.callback = OpenURL(url="spectra/input/@FIBER/qcframe/4x/")
-
+        
     return fig


### PR DESCRIPTION
Addressing issue 197. Upon clicking individual dots in camfiber plots, defaults to calibrated spectrum plot (qcframe) from calibrated camfiber plot and raw spectrum plot (qframe) from raw camfiber plot. The main changes should occur in plots/fiber.py, but relevant taptool in plots/camfiber.py is also updated for completion sake.