### PR TITLE
robust to NIGHT=None; requires latest desispec

### DIFF
--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -20,6 +20,7 @@ import desispec.scripts.preproc
 from nightwatch.qa.base import QA
 
 from .thresholds import write_threshold_json, get_outdir
+from .io import get_night_expid_header
 
 def timestamp():
     return time.strftime('%H:%M')
@@ -257,8 +258,7 @@ def run_qproc(rawfile, outdir, ncpu=None, cameras=None):
         else :
             log.warning('Use FLAVOR instead of missing OBSTYPE')
             obstype = hdr['FLAVOR'].rstrip().upper()
-        night = hdr['NIGHT']
-        expid = hdr['EXPID']
+        night, expid = get_night_expid_header(hdr)
     except KeyError as e :
         log.error(str(e))
         raise(e)
@@ -274,9 +274,10 @@ def run_qproc(rawfile, outdir, ncpu=None, cameras=None):
     else:
         log.warning('No coordinate file for positioner accuracy')
 
-
     #- HACK: Workaround for data on 20190626/27 that have blank NIGHT keywords
-    if night == '        ':
+    #- Note: get_night_expid_header(hdr) should take care of this now, but
+    #-       this is left in for robustness just in case
+    if night == '        ' or night is None:
         log.error('Correcting blank NIGHT keyword based upon directory structure')
         #- /path/to/NIGHT/EXPID/rawfile.fits
         night = os.path.basename(os.path.dirname(os.path.dirname(os.path.abspath(rawfile))))

--- a/py/nightwatch/script.py
+++ b/py/nightwatch/script.py
@@ -83,7 +83,7 @@ def main_monitor(options=None):
     parser.add_argument("--startdate", type=int, default=None, help="Earliest startdate to check for unprocessed nights (YYYYMMDD)")
     parser.add_argument("--batch", "-b", action='store_true', help="spawn qproc data processing to batch job")
     parser.add_argument("--batch-queue", "-q", type=str, default="realtime", help="batch queue to use")
-    parser.add_argument("--batch-time", "-t", type=int, default=10, help="batch job time limit [minutes]")
+    parser.add_argument("--batch-time", "-t", type=int, default=15, help="batch job time limit [minutes]")
     parser.add_argument("--batch-opts", type=str, default="-N 1 -C haswell -A desi", help="Additional batch options")
 
     if options is None:


### PR DESCRIPTION
Opening PR for workaround on some exposures (e.g. on 20210105) that had a blank NIGHT keyword. This version has been running at KPNO for a week, so I'm planning to merge straightaway.