### PR TITLE
Summary details - do not merge

### DIFF
--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -426,22 +426,22 @@ def plot_fractionalresidual(fiber, header, expos, position=False, plot_height=50
         GOODFIBER_X=coords["FIBER_X"][sel],
         GOODFIBER_Y=coords["FIBER_Y"][sel],
         FIBERFLUX_R=flux,
-        MEDIAN_CALIB_FLUX(R)=counts,
+        MEDIAN_CALIB_FLUX=counts,
      ))
 
-    fig = bk.figure(title="Fractional residuals of counts vs. flux", plot_height=plot_height, plot_width=plot_width)
+    fig = bk.figure(title="Fractional residuals of counts vs. flux", plot_height=plot_height, plot_width=plot_width+25)#, toolbar_location=None)
     fig.scatter(coords["FIBER_X"],coords["FIBER_Y"],size=0.5, color='gray')
     mapper = linear_cmap('ratio', palette="Viridis256", low=0.5, high=1.5, nan_color='gray')
     fig.scatter('GOODFIBER_X', 'GOODFIBER_Y', source=source, size=5, color=mapper)
     color_bar = ColorBar(color_mapper=mapper['transform'], label_standoff=12, ticker=BasicTicker(), width=10, formatter=NumeralTickFormatter(format='0.0a'))
     fig.add_layout(color_bar, 'right')
 
-    fig2 = bk.figure(title="Median Calibrated Flux vs. Fiberflux", x_axis_label='FIBERFLUX_R', y_axis_label='MEDIAN_CALIB_FLUX(R)', plot_height=plot_height, plot_width=plot_width)
+    fig2 = bk.figure(title="Median Calibrated Flux vs. Fiberflux", x_axis_label='FIBERFLUX_R', y_axis_label='MEDIAN_CALIB_FLUX(R)', plot_height=plot_height, plot_width=plot_width)#, toolbar_location=None)
     fig2.scatter(flux, counts, size=4)
 
     moontext = ("Moon is " + f'{phase*100:4.1f}' + "% full, " + f'{header["MOONSEP"]:5.1f}' + " deg away, " + f'{moon_el:5.1f}' + " deg above the horizon") if moon_el>-6 else ("Moon is set")
     summarytext = \
-    "Tile " + f'{header["TILEID"]:05d}' + " at RA,Dec " + f'{header["SKYRA"]:5.1f}' + " " + f'{header["SKYDEC"]:+4.1f}' + "and Galactic l,b " + f'{galactic.l.degree:3.1f}' + " " + f'{galactic.b.degree:+2.1f}' + "\n" \
+    "Tile " + f'{header["TILEID"]:05d}' + " at RA,Dec " + f'{header["SKYRA"]:5.1f}' + " " + f'{header["SKYDEC"]:+4.1f}' + " and Galactic l,b " + f'{galactic.l.degree:3.1f}' + " " + f'{galactic.b.degree:+2.1f}' + "\n" \
     + "Airmass " + f'{header["AIRMASS"]:4.2f}' + ", Hour Angle " + f'{header["MOUNTHA"]:+2.0f}' + " deg at UTC " + str(header["DATE-OBS"][11:19]) + "\n" \
     + moontext + "\n" \
     + "r=20 stars yielding " + f'{rstarcountrate:5.1f}' + " counts/ks in R with " + f'{ratio_rms_robust:5.3f}' + " fractional residual" + "\n" \

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -333,7 +333,7 @@ def sun_elevation(header):
         # These keywords were only added in mid-February 2021; return False if not available.
         return False, False
     moon = radec_to_xyz(header["MOONRA"], header["MOONDEC"])
-    phase = (1.0-np.arccos(np.dot(moon,sun))/np.pi)   # 0 = moon, sun together; 1 = opposed.
+    phase = (np.arccos(np.dot(moon,sun))/np.pi)   # 0 = moon, sun together; 1 = opposed.
     return np.arcsin(np.dot(zenith,sun))*180.0/np.pi, phase
 
 def calc_fractionalresidual(fiber, header, expos, position=False):

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -429,14 +429,14 @@ def plot_fractionalresidual(fiber, header, expos, position=False, plot_height=50
         MEDIAN_CALIB_FLUX=counts,
      ))
 
-    fig = bk.figure(title="Fractional residuals of counts vs. flux", plot_height=plot_height, plot_width=plot_width+25)#, toolbar_location=None)
+    fig = bk.figure(title="Fractional residuals of standard star R counts vs flux", plot_height=plot_height-50, plot_width=plot_width+25)#, toolbar_location=None)
     fig.scatter(coords["FIBER_X"],coords["FIBER_Y"],size=0.5, color='gray')
     mapper = linear_cmap('ratio', palette="Viridis256", low=0.5, high=1.5, nan_color='gray')
     fig.scatter('GOODFIBER_X', 'GOODFIBER_Y', source=source, size=5, color=mapper)
     color_bar = ColorBar(color_mapper=mapper['transform'], label_standoff=12, ticker=BasicTicker(), width=10, formatter=NumeralTickFormatter(format='0.0a'))
     fig.add_layout(color_bar, 'right')
 
-    fig2 = bk.figure(title="Median Calibrated Flux vs. Fiberflux", x_axis_label='FIBERFLUX_R', y_axis_label='MEDIAN_CALIB_FLUX(R)', plot_height=plot_height, plot_width=plot_width)#, toolbar_location=None)
+    fig2 = bk.figure(title="Median Calibrated Flux vs Fiberflux for Standard Stars", x_axis_label='FIBERFLUX_R', y_axis_label='MEDIAN_CALIB_FLUX(R)', plot_height=plot_height-50, plot_width=plot_width)#, toolbar_location=None)
     fig2.scatter(flux, counts, size=4)
 
     moontext = ("Moon is " + f'{phase*100:4.1f}' + "% full, " + f'{header["MOONSEP"]:5.1f}' + " deg away, " + f'{moon_el:5.1f}' + " deg above the horizon") if moon_el>-6 else ("Moon is set")

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -405,7 +405,7 @@ def plot_fractionalresidual(fiber, header, expos, position=False):
     linfit = linregress_iter(flux, counts)
     ratio = counts/(linfit.intercept+linfit.slope*flux)
     rsn2 = rstarcountrate**2/rskycounts
-        ratio_quantiles = np.quantile(ratio,[0.16,0.84])
+    ratio_quantiles = np.quantile(ratio,[0.16,0.84])
     ratio_rms_robust = (ratio_quantiles[1]-ratio_quantiles[0])/2.0
     
     moon_el = moon_elevation(header)

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -441,7 +441,7 @@ def plot_fractionalresidual(fiber, header, expos, position=False):
 
     moontext = ("Moon is " + f'{phase*100:4.1f}' + "% full, " + f'{header["MOONSEP"]:5.1f}' + " deg away, " + f'{moon_el:5.1f}' + " deg above the horizon") if moon_el>-6 else ("Moon is set")
     summarytext = \
-    "Tile " + f'{header["TILEID"]:05d}' + " at RA, Dec " + f'{header["SKYRA"]:5.1f}' + f'{header["SKYDEC"]:+4.1f}' + ", Galactic l,b " + f'{galactic.l.degree:3.1f}' + f'{galactic.b.degree:+2.1f}' + "\n" \
+    "Tile " + f'{header["TILEID"]:05d}' + " at RA, Dec " + f'{header["SKYRA"]:5.1f}' + ", " + f'{header["SKYDEC"]:+4.1f}' + ", Galactic l,b " + f'{galactic.l.degree:3.1f}' + ", " + f'{galactic.b.degree:+2.1f}' + "\n" \
     + "Airmass " + f'{header["AIRMASS"]:4.2f}' + ", Hour Angle " + f'{header["MOUNTHA"]:+2.0f}' + " deg at UTC " + str(header["DATE-OBS"][11:19]) + "\n" \
     + moontext + "\n" \
     + "r=20 stars yielding " + f'{rstarcountrate:5.1f}' + " counts/ks in R with " + f'{ratio_rms_robust:5.3f}' + " fractional residual" + "\n" \

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -334,7 +334,7 @@ def sun_elevation(header):
     phase = (1.0-np.arccos(np.dot(moon,sun))/np.pi)   # 0 = moon, sun together; 1 = opposed.
     return np.arcsin(np.dot(zenith,sun))*180.0/np.pi, phase
 
-def plot_fractionalresidual(fiber, header, expos, position=False):
+def plot_fractionalresidual(fiber, header, expos, position=False, plot_height=500, plot_width=500):
     if position==False: position = expos
     bfiber = fiber[np.where(fiber['CAM']=='B')]
     rfiber = fiber[np.where(fiber['CAM']=='R')]
@@ -421,27 +421,27 @@ def plot_fractionalresidual(fiber, header, expos, position=False):
     from bokeh.palettes import Viridis256
     from bokeh.transform import linear_cmap
 
-    sourcedict = {}
-    sourcedict['ratio'] = ratio
-    sourcedict['GOODFIBER_X'] = coords["FIBER_X"][sel]
-    sourcedict['GOODFIBER_Y'] = coords["FIBER_Y"][sel]
-    sourcedict['FIBERFLUX_R'] = flux
-    sourcedict['MEDIAN_CALIB_FLUX(R)'] = counts
-    source = bk.ColumnDataSource(sourcedict)
+    source = bk.ColumnDataSource(data=dict(
+        ratio=ratio,
+        GOODFIBER_X=coords["FIBER_X"][sel],
+        GOODFIBER_Y=coords["FIBER_Y"][sel],
+        FIBERFLUX_R=flux,
+        MEDIAN_CALIB_FLUX(R)=counts,
+     ))
 
-    fig = bk.figure(title="Fractional residuals of counts vs. flux")
+    fig = bk.figure(title="Fractional residuals of counts vs. flux", plot_height=plot_height, plot_width=plot_width)
     fig.scatter(coords["FIBER_X"],coords["FIBER_Y"],size=0.5, color='gray')
     mapper = linear_cmap('ratio', palette="Viridis256", low=0.5, high=1.5, nan_color='gray')
     fig.scatter('GOODFIBER_X', 'GOODFIBER_Y', source=source, size=5, color=mapper)
     color_bar = ColorBar(color_mapper=mapper['transform'], label_standoff=12, ticker=BasicTicker(), width=10, formatter=NumeralTickFormatter(format='0.0a'))
     fig.add_layout(color_bar, 'right')
 
-    fig2 = bk.figure(title="Median Calibrated Flux vs. Fiberflux", x_axis_label='FIBERFLUX_R', y_axis_label='MEDIAN_CALIB_FLUX(R)')
+    fig2 = bk.figure(title="Median Calibrated Flux vs. Fiberflux", x_axis_label='FIBERFLUX_R', y_axis_label='MEDIAN_CALIB_FLUX(R)', plot_height=plot_height, plot_width=plot_width)
     fig2.scatter(flux, counts, size=4)
 
     moontext = ("Moon is " + f'{phase*100:4.1f}' + "% full, " + f'{header["MOONSEP"]:5.1f}' + " deg away, " + f'{moon_el:5.1f}' + " deg above the horizon") if moon_el>-6 else ("Moon is set")
     summarytext = \
-    "Tile " + f'{header["TILEID"]:05d}' + " at RA, Dec " + f'{header["SKYRA"]:5.1f}' + ", " + f'{header["SKYDEC"]:+4.1f}' + ", Galactic l,b " + f'{galactic.l.degree:3.1f}' + ", " + f'{galactic.b.degree:+2.1f}' + "\n" \
+    "Tile " + f'{header["TILEID"]:05d}' + " at RA,Dec " + f'{header["SKYRA"]:5.1f}' + " " + f'{header["SKYDEC"]:+4.1f}' + "and Galactic l,b " + f'{galactic.l.degree:3.1f}' + " " + f'{galactic.b.degree:+2.1f}' + "\n" \
     + "Airmass " + f'{header["AIRMASS"]:4.2f}' + ", Hour Angle " + f'{header["MOUNTHA"]:+2.0f}' + " deg at UTC " + str(header["DATE-OBS"][11:19]) + "\n" \
     + moontext + "\n" \
     + "r=20 stars yielding " + f'{rstarcountrate:5.1f}' + " counts/ks in R with " + f'{ratio_rms_robust:5.3f}' + " fractional residual" + "\n" \

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -436,7 +436,7 @@ def plot_fractionalresidual(fiber, header, expos, position=False):
     color_bar = ColorBar(color_mapper=mapper['transform'], label_standoff=12, ticker=BasicTicker(), width=10, formatter=NumeralTickFormatter(format='0.0a'))
     fig.add_layout(color_bar, 'right')
 
-    fig2 = bk.figure(title="Median Calibration Flux vs. Fiberflux", x_axis_label='FIBERFLUX_R', y_axis_label='MEDIAN_CALIB_FLUX(R)')
+    fig2 = bk.figure(title="Median Calibrated Flux vs. Fiberflux", x_axis_label='FIBERFLUX_R', y_axis_label='MEDIAN_CALIB_FLUX(R)')
     fig2.scatter(flux, counts, size=4)
 
     moontext = ("Moon is " + f'{phase*100:4.1f}' + "% full, " + f'{header["MOONSEP"]:5.1f}' + " deg away, " + f'{moon_el:5.1f}' + " deg above the horizon") if moon_el>-6 else ("Moon is set")

--- a/py/nightwatch/webpages/summary.py
+++ b/py/nightwatch/webpages/summary.py
@@ -114,7 +114,7 @@ def get_summary_plots(qadata, qprocdir=None):
         html_components['FRACTIONALRESIDUAL'] = dict(script=script, div=div)
         script, div = components(fig2)
         html_components['MEDIANFLUX'] = dict(script=script, div=div)
-        html_components['summarytext'] = summarytext.replace("\n", "<br>")
+        html_components['summarytext'] = summarytext#.replace("\n", "<br>")
 
     return html_components
 

--- a/py/nightwatch/webpages/summary.py
+++ b/py/nightwatch/webpages/summary.py
@@ -109,13 +109,16 @@ def get_summary_plots(qadata, qprocdir=None):
     #- Fractional Residuals of counts vs. flux
     if obstype.upper() in ['SCIENCE'] and 'PER_CAMFIBER' in qadata:
         expos = '{:08d}'.format(night) +'/'+ '{:08d}'.format(expid)
-        fig, fig2, summarytext = plot_fractionalresidual(qadata['PER_CAMFIBER'], header, expos, position=False, plot_height=plot_width, plot_width=plot_width)
-        script, div = components(fig)
-        html_components['FRACTIONALRESIDUAL'] = dict(script=script, div=div)
-        script, div = components(fig2)
-        html_components['MEDIANFLUX'] = dict(script=script, div=div)
-        html_components['summarytext'] = summarytext#.replace("\n", "<br>")
-
+        try:
+            fig, fig2, summarytext = plot_fractionalresidual(qadata['PER_CAMFIBER'], header, expos, position=False, plot_height=plot_width, plot_width=plot_width)
+            script, div = components(fig)
+            html_components['FRACTIONALRESIDUAL'] = dict(script=script, div=div)
+            script, div = components(fig2)
+            html_components['MEDIANFLUX'] = dict(script=script, div=div)
+            html_components['summarytext'] = summarytext#.replace("\n", "<br>")
+        except:
+            print("Error: summary statistics not generated")
+            
     return html_components
 
 def write_summary_html(outfile, qadata, qprocdir):

--- a/py/nightwatch/webpages/summary.py
+++ b/py/nightwatch/webpages/summary.py
@@ -109,7 +109,7 @@ def get_summary_plots(qadata, qprocdir=None):
     #- Fractional Residuals of counts vs. flux
     if obstype.upper() in ['SCIENCE'] and 'PER_CAMFIBER' in qadata:
         expos = '{:08d}'.format(night) +'/'+ '{:08d}'.format(expid)
-        fig, fig2, summarytext = plot_fractionalresidual(qadata['PER_CAMFIBER'], header, expos, position=False)
+        fig, fig2, summarytext = plot_fractionalresidual(qadata['PER_CAMFIBER'], header, expos, position=False, plot_height=plot_width, plot_width=plot_width)
         script, div = components(fig)
         html_components['FRACTIONALRESIDUAL'] = dict(script=script, div=div)
         script, div = components(fig2)

--- a/py/nightwatch/webpages/summary.py
+++ b/py/nightwatch/webpages/summary.py
@@ -109,13 +109,12 @@ def get_summary_plots(qadata, qprocdir=None):
     #- Fractional Residuals of counts vs. flux
     if obstype.upper() in ['SCIENCE'] and 'PER_CAMFIBER' in qadata:
         expos = '{:08d}'.format(night) +'/'+ '{:08d}'.format(expid)
-        fig, fig2, abovetext, belowtext  = plot_fractionalresidual(qadata['PER_CAMFIBER'], header, expos, position=False)
+        fig, fig2, summarytext = plot_fractionalresidual(qadata['PER_CAMFIBER'], header, expos, position=False)
         script, div = components(fig)
         html_components['FRACTIONALRESIDUAL'] = dict(script=script, div=div)
         script, div = components(fig2)
         html_components['MEDIANFLUX'] = dict(script=script, div=div)
-        html_components['abovetext'] = abovetext
-        html_components['belowtext'] = belowtext
+        html_components['summarytext'] = summarytext.replace("\n", "<br>")
 
     return html_components
 

--- a/py/nightwatch/webpages/summary.py
+++ b/py/nightwatch/webpages/summary.py
@@ -8,7 +8,7 @@ import jinja2
 from jinja2 import select_autoescape
 
 from .. import io
-from ..plots.camfiber import plot_per_fibernum
+from ..plots.camfiber import plot_per_fibernum, plot_fractionalresidual
 from ..plots.amp import plot_amp_qa
 from ..plots.spectra import plot_spectra_input
 from . import camfiber
@@ -105,6 +105,17 @@ def get_summary_plots(qadata, qprocdir=None):
             fibers, height=300, width=plot_width*2)
         script, div = components(specfig)
         html_components['SPECTRA'] = dict(script=script, div=div, fibers=fibers)
+
+    #- Fractional Residuals of counts vs. flux
+    if obstype.upper() in ['SCIENCE'] and 'PER_CAMFIBER' in qadata:
+        expos = '{:08d}'.format(night) +'/'+ '{:08d}'.format(expid)
+        fig, fig2, abovetext, belowtext  = plot_fractionalresidual(qadata['PER_CAMFIBER'], header, expos, position=False)
+        script, div = components(fig)
+        html_components['FRACTIONALRESIDUAL'] = dict(script=script, div=div)
+        script, div = components(fig2)
+        html_components['MEDIANFLUX'] = dict(script=script, div=div)
+        html_components['abovetext'] = abovetext
+        html_components['belowtext'] = belowtext
 
     return html_components
 
@@ -268,3 +279,4 @@ def write_logfile_html(input, output, night):
     print('Wrote {}'.format(output))
 
     return error_colors.get(error_level)
+

--- a/py/nightwatch/webpages/templates/summary.html
+++ b/py/nightwatch/webpages/templates/summary.html
@@ -4,7 +4,6 @@
 
 {# Each plot is wrapped in if/endif for robustness against missing plots #}
 
-<pre> {{ summarytext }} </pre>
 {% set fulltext = summarytext.split("\n") %}
 {% for line in fulltext %}
     <p> {{ line }} </p>

--- a/py/nightwatch/webpages/templates/summary.html
+++ b/py/nightwatch/webpages/templates/summary.html
@@ -4,7 +4,11 @@
 
 {# Each plot is wrapped in if/endif for robustness against missing plots #}
 
-<p> {{ summarytext }} </p>
+<pre> {{ summarytext }} </pre>
+{% set fulltext = summarytext.split("\n") %}
+{% for line in fulltext %}
+    <p> {{ line }} </p>
+{% endfor %}
 
 <div class="flex-container">
 
@@ -20,6 +24,8 @@
     <div>{{ CALIBFLUX.script | safe }} {{ CALIBFLUX.div | safe }}</div>
 {% endif %}
 
+<br>
+
 {% if FRACTIONALRESIDUAL %}
     <div>{{ FRACTIONALRESIDUAL.script | safe }} {{ FRACTIONALRESIDUAL.div | safe }}</div>
 {% endif %}
@@ -27,6 +33,8 @@
 {% if MEDIANFLUX %}
     <div>{{ MEDIANFLUX.script | safe }} {{ MEDIANFLUX.div | safe }}</div>
 {% endif %}
+
+<br>
 
 {% if SPECTRA %}
     <div>{{ SPECTRA.script | safe }} {{ SPECTRA.div | safe }}</div>

--- a/py/nightwatch/webpages/templates/summary.html
+++ b/py/nightwatch/webpages/templates/summary.html
@@ -4,10 +4,12 @@
 
 {# Each plot is wrapped in if/endif for robustness against missing plots #}
 
-{% set fulltext = summarytext.split("\n") %}
-{% for line in fulltext %}
-    <p> {{ line }} </p>
-{% endfor %}
+{% if summarytext %}
+    {% set fulltext = summarytext.split("\n") %}
+    {% for line in fulltext %}
+        <p> {{ line }} </p>
+    {% endfor %}
+{% endif %}
 
 <div class="flex-container">
 

--- a/py/nightwatch/webpages/templates/summary.html
+++ b/py/nightwatch/webpages/templates/summary.html
@@ -4,7 +4,7 @@
 
 {# Each plot is wrapped in if/endif for robustness against missing plots #}
 
-<pre style="text-align: left; font-family: normal; font-size: 20px; background-color:white;"> {{ abovetext  }} </pre>
+<p> {{ summarytext }} </p>
 
 <div class="flex-container">
 
@@ -20,20 +20,17 @@
     <div>{{ CALIBFLUX.script | safe }} {{ CALIBFLUX.div | safe }}</div>
 {% endif %}
 
-{% if SPECTRA %}
-    <div>{{ SPECTRA.script | safe }} {{ SPECTRA.div | safe }}</div>
-{% endif %}
-
 {% if FRACTIONALRESIDUAL %}
     <div>{{ FRACTIONALRESIDUAL.script | safe }} {{ FRACTIONALRESIDUAL.div | safe }}</div>
 {% endif %}
-
-<pre style="text-align: left; font-family: normal; font-size: 20px; background-color:white;"> {{ belowtext  }} </pre>
 
 {% if MEDIANFLUX %}
     <div>{{ MEDIANFLUX.script | safe }} {{ MEDIANFLUX.div | safe }}</div>
 {% endif %}
 
+{% if SPECTRA %}
+    <div>{{ SPECTRA.script | safe }} {{ SPECTRA.div | safe }}</div>
+{% endif %}
 
 </div>
 

--- a/py/nightwatch/webpages/templates/summary.html
+++ b/py/nightwatch/webpages/templates/summary.html
@@ -4,6 +4,8 @@
 
 {# Each plot is wrapped in if/endif for robustness against missing plots #}
 
+<pre style="text-align: left; font-family: normal; font-size: 20px; background-color:white;"> {{ abovetext  }} </pre>
+
 <div class="flex-container">
 
 {% if READNOISE %}
@@ -21,6 +23,17 @@
 {% if SPECTRA %}
     <div>{{ SPECTRA.script | safe }} {{ SPECTRA.div | safe }}</div>
 {% endif %}
+
+{% if FRACTIONALRESIDUAL %}
+    <div>{{ FRACTIONALRESIDUAL.script | safe }} {{ FRACTIONALRESIDUAL.div | safe }}</div>
+{% endif %}
+
+<pre style="text-align: left; font-family: normal; font-size: 20px; background-color:white;"> {{ belowtext  }} </pre>
+
+{% if MEDIANFLUX %}
+    <div>{{ MEDIANFLUX.script | safe }} {{ MEDIANFLUX.div | safe }}</div>
+{% endif %}
+
 
 </div>
 


### PR DESCRIPTION
These features partially resolve #199. This branch adds several useful summary statistics and two plots to the qa-summary page, including a fractional residuals vs. flux plot and median calibrated flux vs. fiber flux plot (all sourced from @deisenstein's notebook at `/project/projectdirs/desi/users/eisenste/NightWatchVisualizationsDev.ipynb` ). An example can be seen at https://data.desi.lbl.gov/desi/users/benjikan/nightwatch/20210206/00074938/qa-summary-00074938.html, and now also includes the following summary text:
```
570.2 second SCIENCE (sv1elgqso)
Tile 80673 at RA, Dec 85.5, -20.2, Galactic l,b 224.3, -24.0
Airmass 1.66, Hour Angle -10 deg at UTC 03:21:43
Moon is set
r=20 stars yielding 137.0 counts/ks in R with 0.084 fractional residual
Sky yielding 109.9 counts/ks in R
```
(note that if the moon's elevation angle were >-6 deg, the "Moon is set" line would instead read "Moon is 12% full, 123 deg away, 12 deg above the horizon")

The plotting and calculations are packaged in new functions in plots/camfiber.py, while new fields are added in webpages/summary.py and webpages/templates/summary.html. 

The path to spectro files and the nightwatch directory are currently hardcoded (in [lines 356-357](https://github.com/desihub/nightwatch/compare/summary-details?expand=1#diff-f5f13dca6233e5fbe16353bba9501f15f90cf6696e19a3deb4e5dedc1fbcc308R356)) into camfiber.py, since I couldn't find an existing function or global path to either. A simple fix would be to pass the NW directory path as an explicit argument into the function, but I don't know if there's a preferred solution. I can add more documentation to these new functions when that is figured out.
