### PR TITLE
FVC Image Inspection

### DIFF
--- a/py/nightwatch/plots/fvc.py
+++ b/py/nightwatch/plots/fvc.py
@@ -19,7 +19,7 @@ import bokeh
 
 from glob import glob
 
-from plotimage import plot_image
+from ..plots.plotimage import plot_image
 
 def plot_fvc(expos, hdu="F0000", downsample=2):
     '''Plots FVC image

--- a/py/nightwatch/plots/fvc.py
+++ b/py/nightwatch/plots/fvc.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+"""
+Tests with plotting fits images with bokeh
+"""
+
+import sys, os
+import numpy as np
+from bokeh.embed import components
+import jinja2
+import fitsio
+from astropy.io import fits
+# from astropy.visualization import ZScaleInterval
+
+import bokeh
+# import bokeh.plotting as bk
+# from bokeh.models.mappers import LinearColorMapper
+# from bokeh.palettes import cividis, gray
+
+from glob import glob
+
+from plotimage import plot_image
+
+def plot_fvc(expos, hdu="F0000", downsample=2):
+    '''Plots FVC image
+    ARGS:
+        expos : string representing NightWatch exposure directory "day/exposure"
+
+    Options:
+        hdu: HDU of FVC image, default to "F0000"
+        downsample: downsample image NxN
+    '''
+    night, expid = expos.split("/")
+    spectrodata = "/global/cfs/cdirs/desi/spectro/data/" # HARDCODED
+    try: fvcfile = glob(spectrodata+night+'/'+expid+'/'+"fvc-*.fits.fz")[0]
+    except:
+        print("No FVC file found in ", expid)
+        return
+
+    print("\nReading FVC images from file: ", fvcfile)
+
+
+    fvc = fitsio.FITS(fvcfile)
+
+    dat = readchip(fvc, hdu)
+
+    fvcimage = dat[1]
+    print("The medians in each quadrant has been subtracted, then a sqrt stretch applied.")
+    print("No corrections for dark current, flat fielding, or anything else.\n\n")
+
+    n = downsample
+    plottitle = "FVC (HDU={hdu}, Square Root Stretch) {expos} downsampled {n}x{n}".format(hdu=hdu, expos=expos, n=n)
+    fig = plot_image(fvcimage, downsample=n, title=plottitle)
+
+    return fig
+
+def sqrt_stretch(x):
+    return x/np.sqrt(np.abs(x+1e-10))
+
+def readchip(fitsfile, hdu):
+    im = fitsfile[hdu].read()
+    print("Found images of size", np.shape(im), "in HDU", hdu)
+    if (len(np.shape(im))==3):
+        stack = np.mean(im, axis=0)
+        print("Averaging into a stack of this form: ",np.shape(stack))
+    else:
+        stack = im
+        print("One frame.  Not averaging")
+    halfX = np.int(np.shape(stack)[0]/2)
+    halfY = np.int(np.shape(stack)[1]/2)
+    stack_eq = stack.astype('float32')
+
+    median = np.zeros([2,2])
+    median[0][0] = np.median(stack_eq[:halfX, :halfY])
+    median[0][1] = np.median(stack_eq[:halfX, halfY:])
+    median[1][0] = np.median(stack_eq[halfX:, :halfY])
+    median[1][1] = np.median(stack_eq[halfX:, halfY:])
+
+    stack_eq[:halfX,:halfY] = stack_eq[:halfX,:halfY]-median[0][0]
+    stack_eq[:halfX,halfY:] = stack_eq[:halfX,halfY:]-median[0][1]
+    stack_eq[halfX:,:halfY] = stack_eq[halfX:,:halfY]-median[1][0]
+    stack_eq[halfX:,halfY:] = stack_eq[halfX:,halfY:]-median[1][1]
+
+    print("Quadrant Medians:", np.ndarray.flatten(median))
+
+    return stack, sqrt_stretch(stack_eq)
+

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -531,7 +531,7 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
                                         error_colors=error_colors)
 
     from nightwatch.webpages import fvc as web_fvc
-    fvc_output = '{}/qa-amp-{:08d}-fvc.html'.format(expdir, expid)
+    fvc_output = '{}/qa-fvc-{:08d}.html'.format(expdir, expid)
     web_fvc.write_fvc_html(fvc_output, downsample, night, expid)
 
 def write_tables(indir, outdir, expnights=None):

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -530,6 +530,10 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
         web_summary.write_logtable_html(htmlfile, logdir, night, expid, available=log_cams, 
                                         error_colors=error_colors)
 
+    from nightwatch.webpages import fvc as web_fvc
+    fvc_output = '{}/qa-amp-{:08d}-fvc.html'.format(expdir, expid)
+    web_fvc.write_fvc_html(fvc_output, downsample, night, expid)
+
 def write_tables(indir, outdir, expnights=None):
     '''
     Parses directory for available nights, exposures to generate

--- a/py/nightwatch/webpages/fvc.py
+++ b/py/nightwatch/webpages/fvc.py
@@ -1,0 +1,49 @@
+import jinja2
+from jinja2 import select_autoescape
+import bokeh, os, re, sys
+
+from ..plots.fvc import plot_fvc
+from bokeh.embed import components
+
+def write_fvc_html(output, downsample, night, expid):
+    '''
+    Writes the downsampled fvc image to a given output file.
+    Inputs:
+        output: the filepath to write html file to
+        downsample: downsample image NxN
+        night: the night YYYYMMDD the image belongs to
+        expid: the exposure ID of the image
+    '''
+
+    env = jinja2.Environment(
+        loader=jinja2.PackageLoader('nightwatch.webpages', 'templates'),
+        autoescape=select_autoescape(disabled_extensions=('txt',),
+                                     default_for_string=True,
+                                     default=True)
+    )
+
+    template = env.get_template('fvc.html')
+    
+    expos = '{:08d}'.format(night) +'/'+ '{:08d}'.format(expid)
+    zexpid = '{expid:08d}'.format(expid=expid)
+    qatype = 'fvc'
+    
+    fig = plot_fvc(expos, downsample=2) # Downsample chosen for ~10 second load time
+    plot_script, plot_div = components(fig)
+
+    html_components = dict(
+        bokeh_version=bokeh.__version__, night=night,
+        expid=int(str(zexpid)), zexpid=zexpid, num_dirs=2, qatype=qatype,
+        plot_script=plot_script, plot_div=plot_div,
+    )
+    
+    html = template.render(**html_components)
+
+    #- Write HTML text to the output file
+    with open(output, 'w') as fx:
+        fx.write(html)
+
+    print('Wrote {}'.format(output))
+    
+
+    

--- a/py/nightwatch/webpages/templates/fvc.html
+++ b/py/nightwatch/webpages/templates/fvc.html
@@ -1,0 +1,22 @@
+{% extends "qabase.html" %}
+{% block body %}
+
+<style>
+.container{
+  display: flex;
+}
+</style>
+
+<header>
+  FVC Shutter Inspection
+</header>
+
+<div class="container">
+
+  {# FVC Image #}
+  <div class=flex-item>
+      <div>{{ plot_script | safe }} {{plot_div | safe }}</div>
+  </div>
+
+</div>
+{% endblock %}

--- a/py/nightwatch/webpages/templates/qabase.html
+++ b/py/nightwatch/webpages/templates/qabase.html
@@ -21,6 +21,8 @@
       </ul>
   </li>
   
+  <li><a id="fvc" href="{% for i in range(num_dirs) %}../{% endfor %}{{night}}/{{zexpid}}/qa-amp-{{ zexpid }}-fvc.html">fvc</a></li>
+
   <li class="dropdown"><a id="spectra" href = "{% for i in range(num_dirs) %}../{% endfor %}{{night}}/{{zexpid}}/spectra/input">spectra</a>
       <ul class="dropdown-content">
         <a id="input" href="{% for i in range(num_dirs) %}../{% endfor %}{{night}}/{{zexpid}}/spectra/input">input</a>

--- a/py/nightwatch/webpages/templates/qabase.html
+++ b/py/nightwatch/webpages/templates/qabase.html
@@ -21,7 +21,7 @@
       </ul>
   </li>
   
-  <li><a id="fvc" href="{% for i in range(num_dirs) %}../{% endfor %}{{night}}/{{zexpid}}/qa-amp-{{ zexpid }}-fvc.html">fvc</a></li>
+  <li><a id="fvc" href="{% for i in range(num_dirs) %}../{% endfor %}{{night}}/{{zexpid}}/qa-fvc-{{ zexpid }}.html">fvc</a></li>
 
   <li class="dropdown"><a id="spectra" href = "{% for i in range(num_dirs) %}../{% endfor %}{{night}}/{{zexpid}}/spectra/input">spectra</a>
       <ul class="dropdown-content">


### PR DESCRIPTION
This feature closes #204. The generated plot comes from @deisenstein's notebook (in /project/projectdirs/desi/users/eisenste/NightWatchVisualizationsDev.ipynb) and displays the image from the FVC, median-subtracted by quadrant with a square root stretch. The image can be accessed from a new menu option titled 'fvc', and is grayscale with a 2x2 downsampling to keep reasonable page load times (<10 seconds).

An example of the FVC shutter working properly can be found at https://data.desi.lbl.gov/desi/users/benjikan/nightwatch/20210208/00075117/qa-fvc-00075117.html. 
An example with shutter trail streaking is https://data.desi.lbl.gov/desi/users/benjikan/nightwatch/20201230/00070062/qa-fvc-00070062.html.

The plot is created with plot_fvc in plots/fvc.py (using plot_image from plots/plotimage.py), and saved with the fvc.html template via write_fvc_html in webpages/fvc.py. Note that plot_fvc uses a hardcoded path to the spectro directory to access the FVC fits file. This may not be that much of an issue, but there might be a more preferred way of doing that.