### PR TITLE
Addressed Issue 214

### DIFF
--- a/py/nightwatch/webpages/camfiber.py
+++ b/py/nightwatch/webpages/camfiber.py
@@ -311,12 +311,12 @@ def write_htmlfile(layout, template, outfile, header):
     else :
         program = header['PROGRAM'].rstrip()
     exptime = header['EXPTIME']
-
+    focalplane = 'focalplane_plots' in outfile
+    positioning = 'posacc_plots' in outfile
     components_dict = dict(
         bokeh_version=bokeh.__version__, exptime='{:.1f}'.format(exptime),
         night=night, expid=expid, zexpid='{:08d}'.format(expid),
-        obstype=obstype, program=program, qatype = 'camfiber',
-        num_dirs=2,        
+        obstype=obstype, program=program, qatype = 'camfiber',focalplane = focalplane,positioning = positioning,     num_dirs=2,        
     )
 
     script, div = components(layout)

--- a/py/nightwatch/webpages/templates/qabase.html
+++ b/py/nightwatch/webpages/templates/qabase.html
@@ -83,6 +83,10 @@ function get_explinks(links) {
         "../../../../"+next_item.night+"/"+next_item.zexpid+"/spectra/input/";
         {% elif logfile %}
           "../../"+next_item.night+"/"+next_item.zexpid+"/qa-summary-"+next_item.zexpid+"-logfiles_table.html";
+        {% elif focalplane %}
+          "../../"+next_item.night+"/"+next_item.zexpid+"/qa-{{ qatype }}-"+next_item.zexpid+"-focalplane_plots.html";
+        {% elif positioning %}
+          "../../"+next_item.night+"/"+next_item.zexpid+"/qa-{{ qatype }}-"+next_item.zexpid+"-posacc_plots.html";
         {% else %}
           "../../"+next_item.night+"/"+next_item.zexpid+"/qa-{{ qatype }}-"+next_item.zexpid+".html";
         {% endif %}
@@ -105,6 +109,10 @@ function get_explinks(links) {
         "../../../../"+prev_item.night+"/"+prev_item.zexpid+"/spectra/input/";
         {% elif logfile %}
           "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-summary-"+prev_item.zexpid+"-logfiles_table.html";
+        {% elif focalplane %}
+          "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-{{ qatype }}-"+prev_item.zexpid+"-focalplane_plots.html";
+        {% elif positioning %}
+          "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-{{ qatype }}-"+prev_item.zexpid+"-posacc_plots.html";
         {% else %}
           "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-{{ qatype }}-"+prev_item.zexpid+".html";
         {% endif %}
@@ -130,3 +138,8 @@ document.getElementById("{{ qatype }}").className = "current_page";
 
 {% block body %}
 {% endblock %}
+
+
+
+
+


### PR DESCRIPTION
This Pull Request resolves ISSUE #214 : On the Nightwatch focal plane plot page, the prev/next buttons take us to the metric-vs-fiber view instead of the metric-vs-xy focalplane view.

These errors persisted in the Camfiber/ Positioning subsection as well. We addressed these issues by adding flags in the write_htmlfile function of Camfiber.py (Lines 314-315):
focalplane = 'focalplane_plots' in outfile
positioning = 'posacc_plots' in outfile
And then we added additional conditionals to catch the flags and to accurately construct the Previous and Next navigations in qabase.html (lines 86-89, 112-115):
{% elif focalplane %}
        "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-{{ qatype }}-"+prev_item.zexpid+"-focalplane_plots.html";
        {% elif positioning %}
          "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-{{ qatype }}-"+prev_item.zexpid+"-posacc_plots.html";

{% elif focalplane %}
          "../../"+next_item.night+"/"+next_item.zexpid+"/qa-{{ qatype }}-"+next_item.zexpid+"-focalplane_plots.html";
        {% elif positioning %}
          "../../"+next_item.night+"/"+next_item.zexpid+"/qa-{{ qatype }}-"+next_item.zexpid+"-posacc_plots.html";

After making the above changes, we noted that:
•	Clicking ‘Previous/Next’ takes you to the focalplane plot of the Previous/Next exposure as well.
•	Clicking ‘Previous/Next’ takes you to the Positioner Accuracy plot of the Previous/Next exposure as well.

While trying to replicate this issue, we came across another issue. Nightwatch was looking for READNOISE-20210205-DARK.json. file which was not there in the repo. To enable testing and debugging, we copied one of the earlier DARK files that did exist. We don’t believe that missing file is correlated with the matter of Issue 214, but (@sbailey) it seems that the 20210205 file may need to be uploaded to the proper (database?) area.
