### PR TITLE
Include image masks in amplifier QA

### DIFF
--- a/py/nightwatch/plots/amp.py
+++ b/py/nightwatch/plots/amp.py
@@ -160,7 +160,7 @@ def plot_amp_cam_qa(data, name, cam, labels, title, lower=None, upper=None,
         upper_err += upper[cam_val][1]
         cam_amp_keys = amp_keys[cam_val]
         
-        if name in ['COSMICS_RATE']:
+        if name in ['COSMICS_RATE', 'FRAC_MASKED']:
             lower_err = [lower_err]*len(data_val)
             lower_warn = [lower_warn]*len(data_val)
             upper_warn = [upper_warn]*len(data_val)

--- a/py/nightwatch/plots/plotimage.py
+++ b/py/nightwatch/plots/plotimage.py
@@ -98,19 +98,25 @@ def main(input_in = None, output_in = None, downsample_in = None):
 
     with fits.open(img_input) as hdul:
         image = hdul[0].data
+        mask = (hdul[2].data == 0).astype(np.uint8)
 
-    short_title = '{basename} {n}x{n}'.format(basename=os.path.splitext(basename)[0], n=n)
-    long_title = '{basename} downsampled {n}x{n}'.format(basename=basename, n=n)
+    short_img_title = '{basename} {n}x{n}'.format(basename=os.path.splitext(basename)[0], n=n)
+    long_img_title = '{basename} downsampled {n}x{n}'.format(basename=basename, n=n)
+    long_mask_title = '{basename} mask downsampled {n}x{n}'.format(basename=basename, n=n)
 
-    fig = plot_image(image, downsample=n, title=long_title)
+    fig_img = plot_image(image, downsample=n, title=long_img_title)
+    fig_mask = plot_image(mask, downsample=n, title=long_mask_title)
+    c = bokeh.layouts.column(fig_img, fig_mask)
 
     if (output != None):
-        bk.output_file(output, title=short_title, mode='inline')
-        fig = plot_image(image, downsample=n, title=long_title)
-        bk.save(fig)
+        bk.output_file(output, title=short_img_title, mode='inline')
+        fig_img = plot_image(image, downsample=n, title=long_img_title)
+        fig_mask = plot_image(mask, downsample=n, title=long_mask_title)
+        c = bokeh.layouts.column(fig_img, fig_mask)
+        bk.savep(c)
         print('Wrote {}'.format(output))
 
-    return components(fig)
+    return components(c)
 
 if __name__ == '__main__':
     main()

--- a/py/nightwatch/plots/plotimage.py
+++ b/py/nightwatch/plots/plotimage.py
@@ -15,6 +15,7 @@ from astropy.visualization import ZScaleInterval
 import bokeh
 import bokeh.plotting as bk
 from bokeh.models.mappers import LinearColorMapper
+from bokeh.models.widgets import Panel, Tabs
 from bokeh.palettes import cividis, gray
 
 def downsample_image(image, n):
@@ -105,18 +106,26 @@ def main(input_in = None, output_in = None, downsample_in = None):
     long_mask_title = '{basename} mask downsampled {n}x{n}'.format(basename=basename, n=n)
 
     fig_img = plot_image(image, downsample=n, title=long_img_title)
+    tab1 = Panel(child=fig_img, title="CCD Image")
+
     fig_mask = plot_image(mask, downsample=n, title=long_mask_title)
-    c = bokeh.layouts.column(fig_img, fig_mask)
+    tab2 = Panel(child=fig_mask, title="Mask")
+
+    tabs = Tabs(tabs=[tab1, tab2])
 
     if (output != None):
         bk.output_file(output, title=short_img_title, mode='inline')
         fig_img = plot_image(image, downsample=n, title=long_img_title)
+        tab1 = Panel(child=fig_img, title="CCD Image")
+
         fig_mask = plot_image(mask, downsample=n, title=long_mask_title)
-        c = bokeh.layouts.column(fig_img, fig_mask)
-        bk.savep(c)
+        tab2 = Panel(child=fig_mask, title="Mask")
+
+        tabs = Tabs(tabs=[tab1, tab2])
+        bk.savep(tabs)
         print('Wrote {}'.format(output))
 
-    return components(c)
+    return components(tabs)
 
 if __name__ == '__main__':
     main()

--- a/py/nightwatch/qa/amp.py
+++ b/py/nightwatch/qa/amp.py
@@ -130,12 +130,16 @@ def get_dico(self, filename, amp):
     else:
         submask = mask[ny//2:, nx//2:]
 
+    #- Fraction of the amp pixels masked out, for any reason.
+    frmask = np.sum(submask != 0) / submask.size
+
     #- Number of cosmics per minute on this amplifier
     num_cosmics = self.count_cosmics(submask)
     cosmics_rate = (num_cosmics / (exptime/60) )
 
     dico = {'NIGHT': night, 'EXPID': expid, 'SPECTRO': spectro, 'CAM': cam, 'AMP': amp,
-            'READNOISE': readnoise, 'BIAS': biaslevel, 'COSMICS_RATE': cosmics_rate
+            'READNOISE': readnoise, 'BIAS': biaslevel, 'COSMICS_RATE': cosmics_rate,
+            'FRAC_MASKED': frmask
            }
         
     return collections.OrderedDict(**dico)

--- a/py/nightwatch/threshold_files/FRAC_MASKED-20211226.json
+++ b/py/nightwatch/threshold_files/FRAC_MASKED-20211226.json
@@ -1,0 +1,3 @@
+{"R": {"lower_err": 0, "lower": 0, "upper": 0.33, "upper_err": 0.5},
+ "B": {"lower_err": 0, "lower": 0, "upper": 0.33, "upper_err": 0.5},
+ "Z": {"lower_err": 0, "lower": 0, "upper": 0.33, "upper_err": 0.5}}

--- a/py/nightwatch/webpages/amp.py
+++ b/py/nightwatch/webpages/amp.py
@@ -85,6 +85,15 @@ def write_amp_html(outfile, data, header):
     script, div = components(fig)
     html_components['COSMICS_RATE'] = dict(script=script, div=div)
 
+    #- Fraction of amplifier masked
+    frmask_file = pick_threshold_file('FRAC_MASKED', night, in_nightwatch=True)
+    lower_frmask, upper_frmask, frmask_keys = get_thresholds(frmask_file, return_keys=True)
+    fig = plot_amp_qa(data, 'FRAC_MASKED', lower=lower_frmask, upper=upper_frmask,
+        amp_keys=frmask_keys, title='CCD Amplifier masked fraction',
+        ymin=[-0.1, -0.1, -0.1], ymax=[1.1, 1.1, 1.1])
+    script, div = components(fig)
+    html_components['FRAC_MASKED'] = dict(script=script, div=div)
+
     #- Combine template + components -> HTML
     html = template.render(**html_components)
 

--- a/py/nightwatch/webpages/templates/amp.html
+++ b/py/nightwatch/webpages/templates/amp.html
@@ -16,4 +16,8 @@
     <div>{{ COSMICS_RATE.script | safe }} {{ COSMICS_RATE.div | safe }}</div>
 {% endif %}
 
+{% if FRAC_MASKED %}
+    <div>{{ FRAC_MASKED.script | safe }} {{ FRAC_MASKED.div | safe }}</div>
+{% endif %}
+
 {% endblock %}


### PR DESCRIPTION
PR to address #241 by adding two plots to the amplifier QA.
1. Plot the fraction of masked amplifier pixels at the bottom of the qa-amp page and raise errors if the fraction is large (e.g., https://data.desi.lbl.gov/desi/users/sybenzvi/nightwatch/20220102/00116382/qa-amp-00116382.html).
2. Plot the image mask below the CCD image from preproc. E.g., the BADREADNOISE mask in 116382 shows why no cosmics were found in z3D: https://data.desi.lbl.gov/desi/users/sybenzvi/nightwatch/20220102/00116382/preproc-z3-00116382-4x.html.