### PR TITLE
Check environment and clean up path join.

### DIFF
--- a/py/nightwatch/webpages/camfiber.py
+++ b/py/nightwatch/webpages/camfiber.py
@@ -201,7 +201,8 @@ def get_posacc_cd(header):
 
     # Useful for offline tests: backup location for coordfiles at NERSC.
     if not os.path.exists(coordfile):
-        coordfile = '/'.join([os.environ['DESI_SPECTRO_DATA'], coordfile])
+        if 'DESI_SPECTRO_DATA' in os.environ:
+            coordfile = os.path.join(os.environ['DESI_SPECTRO_DATA'], coordfile)
 
     if os.path.isfile(coordfile):
         df = Table(fitsio.read(coordfile)).to_pandas()


### PR DESCRIPTION
Add an if guard for the existence of DESI_SPECTRO_DATA before attempting to prepend it to the coordinates file. Fixes a crash in the pos_acc module at KPNO when the coordinates file isn't present.