### PR TITLE
Camfiber pos fixed

### DIFF
--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -140,7 +140,6 @@ def plot_camfib_fot(cds, attribute, cameras, percentiles={},
         in_cam = np.char.upper(np.array(cds.data['CAM']).astype(str)) == c.upper()
         cam_metric = metric[in_cam]
 
-
         fig, hfig = plot_fibers_focalplane(cds, attribute, cam=c,
                         percentile=percentiles.get(c),
                         zmin=zmins.get(c), zmax=zmaxs.get(c),

--- a/py/nightwatch/plots/fiber.py
+++ b/py/nightwatch/plots/fiber.py
@@ -58,6 +58,11 @@ def plot_fibers_focalplane(source, name, cam='',
     cam_metric = full_metric[in_cam]
 
     pmin_full, pmax_full = np.percentile(cam_metric, (2.5, 97.5))
+    
+    #adjustment for the 'all fibers in blue' error:
+    if len(np.unique(cam_metric))==2:
+        pmin_full, pmax_full = np.percentile(cam_metric, (1.0,100.0))
+
 
     #- Generate colors for both plots
     if not palette:
@@ -75,6 +80,7 @@ def plot_fibers_focalplane(source, name, cam='',
     '''
     booleans_metric = np.char.upper(np.array(source.data['CAM']).astype(str)) == cam.upper()
     view_metric = CDSView(source=source, filters=[BooleanFilter(booleans_metric)])
+
 
     #- Plot only the fibers which measured the metric
     s = fig.scatter('X', 'Y', source=source, view=view_metric, color=mapper,


### PR DESCRIPTION
Fix to prevent all fibers in the "fibers on targets" plot from turning blue if the lower and upper percentiles of the S/N distribution aren't quite right. Addresses the unresolved first issue raised in #208.