### PR TITLE
Fix dx jan22

### DIFF
--- a/py/nightwatch/plots/camera.py
+++ b/py/nightwatch/plots/camera.py
@@ -5,7 +5,7 @@ from bokeh.layouts import column
 from bokeh.models.tickers import FixedTicker
 from astropy.table import Table
 
-def plot_camera_qa(table, attribute, lower=None, upper=None, height=225, width=450, title=None, line0 = True, minmax=None):
+def plot_camera_qa(table, attribute, unit=None, lower=None, upper=None, height=225, width=450, title=None, line0 = True, minmax=None):
     '''
     Creates 3 plots of an attribute vs Spectrograph number, corresponding to
     R, B, Z cameras.
@@ -15,6 +15,7 @@ def plot_camera_qa(table, attribute, lower=None, upper=None, height=225, width=4
         attribute : string that is a column name of table
 
     Options :
+        unit : string that gives the column units
         lower : list of lower per_camera thresholds from thresholds.get_thresholds()
             format: [[lower_errB, lowerB], [lower_errR, lowerR], [lower_errZ, lowerZ]]
         upper : list of upper per_camera thresholds from thresholds.get_thresholds() 
@@ -64,7 +65,11 @@ def plot_camera_qa(table, attribute, lower=None, upper=None, height=225, width=4
         if cam == 'Z':
             fig.xaxis.axis_label = "Spectrograph number"
             fig.plot_height = height+25
-        fig.yaxis.axis_label = attribute
+
+        if unit is None:
+            fig.yaxis.axis_label = attribute
+        else:
+            fig.yaxis.axis_label = f'{attribute}  ({unit})'
         
         if lower is not None and upper is not None:
             mean_range = BoxAnnotation(bottom=lower[keys[cam]][1][0], top=upper[keys[cam]][0][0], fill_color='green', fill_alpha=0.1)

--- a/py/nightwatch/plots/camera.py
+++ b/py/nightwatch/plots/camera.py
@@ -5,6 +5,61 @@ from bokeh.layouts import column
 from bokeh.models.tickers import FixedTicker
 from astropy.table import Table
 
+
+def get_qa_colors(data, lower_err, lower, upper, upper_err, basecolor='black'):
+    '''takes in camera QA data and the acceptable threshold for that metric.
+    Args: 
+        data: array of QA data 
+        lower_err: array of lower thresholds that trigger errors
+        lower: array of lower thresholds that trigger warnings
+        upper: array of upper thresholds that trigger warnings
+        upper_err: array of upper thresholds that trigger errors
+    Output: array of colors to be put into a ColumnDataSource
+    '''
+    colors = []
+    for i in range(len(data)):
+        if lower == None or upper == None:
+            continue
+        if data[i] <= lower_err:
+            colors.append('red')
+        if data[i] > lower_err and data[i] <= lower:
+            colors.append('orange')
+        if data[i] > lower and data[i] < upper:
+            colors.append(basecolor)
+        if data[i] >= upper and data[i] < upper_err:
+            colors.append('orange')
+        if data[i] >= upper_err:
+            colors.append('red')
+    return colors
+
+
+def get_qa_size(data, lower_err, lower, upper, upper_err):
+    '''takes in camera QA data and the acceptable threshold for that metric
+    Args: 
+        data: array of QA data
+        lower_err: array of lower thresholds that trigger errors
+        lower: array of lower thresholds that trigger warnings
+        upper: array of upper thresholds that trigger warnings
+        upper_err: array of upper thresholds that trigger errors
+    Output: array of sizes for markers to be put into a ColumnDataSource
+    '''
+    sizes = []
+    for i in range(len(data)):
+        if lower == None or upper == None:
+            continue
+        if data[i] <= lower_err:
+            sizes.append('9')
+        if data[i] > lower_err and data[i] <= lower:
+            sizes.append('9')
+        if data[i] > lower and data[i] < upper:
+            sizes.append('4')
+        if data[i] >= upper and data[i] < upper_err:
+            sizes.append('9')
+        if data[i] >= upper_err:
+            sizes.append('9')
+    return sizes
+
+
 def plot_camera_qa(table, attribute, unit=None, lower=None, upper=None, height=225, width=450, title=None, line0 = True, minmax=None):
     '''
     Creates 3 plots of an attribute vs Spectrograph number, corresponding to
@@ -35,9 +90,9 @@ def plot_camera_qa(table, attribute, unit=None, lower=None, upper=None, height=2
 
     cam_figs=[]
 
-    colors = {"B":"blue", "R":"red", "Z":"green"}
+    camcolors = {"B":"blue", "R":"red", "Z":"green"}
     keys = {'B':0, 'R':1, 'Z':2}
-    for cam in ["B", "R", "Z"]:
+    for cam in 'BRZ':
         
         cam_table = astrotable[astrotable["CAM"]==cam]
 
@@ -47,13 +102,36 @@ def plot_camera_qa(table, attribute, unit=None, lower=None, upper=None, height=2
             continue
 
         fig = bk.figure(plot_height=height, plot_width=width, title = title+" "+cam, tools=['reset', 'box_zoom', 'pan'])
-        source = ColumnDataSource(data=dict(
-            SPECTRO = cam_table["SPECTRO"],
-            MEANattr = cam_table["MEAN"+attribute],
-            MINattr = cam_table["MIN"+attribute],
-            MAXattr = cam_table["MAX"+attribute]
-        ))
-        fig.circle(source=source, x="SPECTRO", y="MEANattr", color=colors[cam])
+
+        if attribute == 'DX' or attribute == 'DY':
+            k = keys[cam]
+            lower_err  = lower[k][0][0] + lower[k][1][0]
+            lower_warn = lower[k][1][0]
+            upper_warn = upper[k][0][0]
+            upper_err  = upper[k][0][0] + upper[k][1][0]
+
+            colors = get_qa_colors(cam_table['MEAN'+attribute], lower_err, lower_warn, upper_warn, upper_err, basecolor=camcolors[cam])
+            sizes = get_qa_size(cam_table['MEAN'+attribute], lower_err, lower_warn, upper_warn, upper_err)
+
+            source = ColumnDataSource(data=dict(
+                SPECTRO = cam_table["SPECTRO"],
+                MEANattr = cam_table["MEAN"+attribute],
+                MINattr = cam_table["MIN"+attribute],
+                MAXattr = cam_table["MAX"+attribute],
+                colors = colors,
+                sizes = sizes
+            ))
+
+            fig.circle(source=source, x="SPECTRO", y="MEANattr", color='colors', size='sizes')
+        else:
+            source = ColumnDataSource(data=dict(
+                SPECTRO = cam_table["SPECTRO"],
+                MEANattr = cam_table["MEAN"+attribute],
+                MINattr = cam_table["MIN"+attribute],
+                MAXattr = cam_table["MAX"+attribute]
+            ))
+            fig.circle(source=source, x="SPECTRO", y="MEANattr", color=camcolors[cam])
+
         fig.circle(source=source, x="SPECTRO", y="MAXattr", fill_alpha=0, line_alpha=0)
         fig.circle(source=source, x="SPECTRO", y="MINattr", fill_alpha=0, line_alpha=0)
         if line0:

--- a/py/nightwatch/qa/status.py
+++ b/py/nightwatch/qa/status.py
@@ -76,9 +76,9 @@ def get_status(qadata, night):
         filepath = pick_threshold_file(metric, night)
         with open(filepath, 'r') as json_file:
             thresholds = json.load(json_file)
-        for cam in [b'B', b'R', b'Z']:
+        for cam in 'BRZ':
             for spec in range(0, 10):
-                key = cam.decode('utf-8')
+                key = cam
                 status_loc = (status['PER_CAMERA']['CAM'] == cam) & (status['PER_CAMERA']['SPECTRO']==spec)
                 data_loc = (cam_data['CAM'] == cam) & (cam_data['SPECTRO']==spec)
                 if thresholds[key]['lower'] != None and thresholds[key]['upper'] != None:

--- a/py/nightwatch/threshold_files/DX-20220112.json
+++ b/py/nightwatch/threshold_files/DX-20220112.json
@@ -1,0 +1,3 @@
+{"R": {"lower_err": -1, "lower": -1, "upper": 1, "upper_err": 1},
+ "B": {"lower_err": -1, "lower": -1, "upper": 1, "upper_err": 1},
+ "Z": {"lower_err": -1, "lower": -1, "upper": 1, "upper_err": 1}}

--- a/py/nightwatch/threshold_files/DY-20220112.json
+++ b/py/nightwatch/threshold_files/DY-20220112.json
@@ -1,0 +1,3 @@
+{"R": {"lower_err": -1, "lower": -1, "upper": 1, "upper_err": 1},
+ "B": {"lower_err": -1, "lower": -1, "upper": 1, "upper_err": 1},
+ "Z": {"lower_err": -1, "lower": -1, "upper": 1, "upper_err": 1}}

--- a/py/nightwatch/webpages/camera.py
+++ b/py/nightwatch/webpages/camera.py
@@ -63,7 +63,7 @@ def write_camera_html(outfile, data, header):
     lower_dx, upper_dx = get_thresholds(dx_file)
     if "MEANDX" in data.dtype.names:
         fig = plot_camera_qa(data, 'DX', lower=lower_dx, upper=upper_dx, title='DX with camera',
-                minmax=(-0.3, 0.3), height=200, width=plot_width)
+                minmax=(-4, 4), height=200, width=plot_width)
         script, div = components(fig)
         html_components['DX'] = dict(script=script, div=div)
     
@@ -71,7 +71,7 @@ def write_camera_html(outfile, data, header):
     lower_dy, upper_dy = get_thresholds(dy_file)
     if "MEANDY" in data.dtype.names:
         fig = plot_camera_qa(data, 'DY', lower=lower_dy, upper=upper_dy, title='DY with camera',
-                minmax=(-0.3, 0.3), height=200, width=plot_width)
+                minmax=(-4, 4), height=200, width=plot_width)
         script, div = components(fig)
         html_components['DY'] = dict(script=script, div=div)
 

--- a/py/nightwatch/webpages/camera.py
+++ b/py/nightwatch/webpages/camera.py
@@ -62,23 +62,23 @@ def write_camera_html(outfile, data, header):
     dx_file = pick_threshold_file('DX', night, in_nightwatch=True)
     lower_dx, upper_dx = get_thresholds(dx_file)
     if "MEANDX" in data.dtype.names:
-        fig = plot_camera_qa(data, 'DX', lower=lower_dx, upper=upper_dx, title='DX with camera',
-                minmax=(-4, 4), height=200, width=plot_width)
+        fig = plot_camera_qa(data, 'DX', unit='pixels', lower=lower_dx, upper=upper_dx, title='DX with camera',
+                minmax=(-3, 3), height=200, width=plot_width)
         script, div = components(fig)
         html_components['DX'] = dict(script=script, div=div)
     
     dy_file = pick_threshold_file('DY', night, in_nightwatch=True)
     lower_dy, upper_dy = get_thresholds(dy_file)
     if "MEANDY" in data.dtype.names:
-        fig = plot_camera_qa(data, 'DY', lower=lower_dy, upper=upper_dy, title='DY with camera',
-                minmax=(-4, 4), height=200, width=plot_width)
+        fig = plot_camera_qa(data, 'DY', unit='pixels', lower=lower_dy, upper=upper_dy, title='DY with camera',
+                minmax=(-3, 3), height=200, width=plot_width)
         script, div = components(fig)
         html_components['DY'] = dict(script=script, div=div)
 
     xsig_file = pick_threshold_file('XSIG', night, in_nightwatch=True)
     lower_xsig, upper_xsig = get_thresholds(xsig_file)
     if "MEANXSIG" in data.dtype.names:
-        fig = plot_camera_qa(data, 'XSIG', lower=lower_xsig, upper=upper_xsig, title='XSIG with camera',
+        fig = plot_camera_qa(data, 'XSIG', unit='pixels', lower=lower_xsig, upper=upper_xsig, title='XSIG with camera',
                 line0=False, minmax=(0.8, 1.2), height=200, width=plot_width)
         script, div = components(fig)
         html_components['XSIG'] = dict(script=script, div=div)
@@ -86,7 +86,7 @@ def write_camera_html(outfile, data, header):
     ysig_file = pick_threshold_file('YSIG', night, in_nightwatch=True)
     lower_ysig, upper_ysig = get_thresholds(ysig_file)
     if "MEANYSIG" in data.dtype.names:
-        fig = plot_camera_qa(data, 'YSIG', lower=lower_ysig, upper=upper_ysig, title='YSIG with camera',
+        fig = plot_camera_qa(data, 'YSIG', unit='pixels', lower=lower_ysig, upper=upper_ysig, title='YSIG with camera',
                 line0=False, minmax=(0.8, 1.2), height=200, width=plot_width)
         script, div = components(fig)
         html_components['YSIG'] = dict(script=script, div=div)


### PR DESCRIPTION
Fixed broken handling of DX and DY trace shifts:
- Warning threshold set to +/-1 pixels, error threshold set to +/-2 pixels.
- Values above threshold are marked in the plot similarly to warning and error values in the amp QA plots.
- Warning and error states are reported in the **camera** column of the exposure summary tables.

Example: QA night 20220113 expid 118482 (compare to [online Nightwatch plots](https://nightwatch.desi.lbl.gov/20220113/00118482/qa-camera-00118482.html)): 
<img width="1542" alt="nightwatch_dx_fix" src="https://user-images.githubusercontent.com/7385438/149606363-5970adbb-a1cf-4c57-82ab-0e89f159450b.png">

This PR will address #242. Before merging the DX and DY threshold files should be rewritten to match the formats used in the amplifier READNOISE and COSMICS rate config files.