### PR TITLE
Convert B camera 0 cosmics errors -> warnings.

### DIFF
--- a/py/nightwatch/threshold_files/COSMICS_RATE-20211226-ZERO.json
+++ b/py/nightwatch/threshold_files/COSMICS_RATE-20211226-ZERO.json
@@ -1,3 +1,3 @@
-{"R": {"lower_err": 0, "lower": 1, "upper": 80, "upper_err": 99.13253361717676},
- "B": {"lower_err": 0, "lower": 1, "upper": 41.62925733, "upper_err": 50.86724008},
- "Z": {"lower_err": 0, "lower": 1, "upper": 80, "upper_err": 191.19929794384203}}
+{"R": {"lower_err":  0, "lower": 1, "upper": 80, "upper_err": 99.13253361717676},
+ "B": {"lower_err": -1, "lower": 1, "upper": 41.62925733, "upper_err": 50.86724008},
+ "Z": {"lower_err":  0, "lower": 1, "upper": 80, "upper_err": 191.19929794384203}}


### PR DESCRIPTION
This PR will mitigate issue #241. Most of the spurious errors where cosmic rate = 0 seem to be downward statistical fluctuations in the B camera during ZERO exposures. A rate of 0 will now produce a warning rather than an error. Since we are reclassifying rate=0 states rather than tracking drifts in the CCDs, the change is being applied to an existing cosmics rate threshold file for ZEROs only.