### PR TITLE
Fix kwargs incompatible with bokeh version at KPNO.

### DIFF
--- a/py/nightwatch/plots/amp.py
+++ b/py/nightwatch/plots/amp.py
@@ -306,9 +306,8 @@ def plot_amp_qa(data, name, lower=None, upper=None, amp_keys=None, title=None, p
                      tools=[])
 
     # Use the help tool to redirect users to the DESI Nightwatch QA wiki Q&A
-    axis.add_tools(HelpTool(description='See the DESI wiki for details\non CCD amplifier QA',
-                            redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Amplifier',
-                            syncable=False))
+    axis.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non CCD amplifier QA',
+                            redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Amplifier'))
 
     axis.line(x=labels, y=0, line_color=None)
     axis.grid.grid_line_color=None

--- a/py/nightwatch/plots/camera.py
+++ b/py/nightwatch/plots/camera.py
@@ -104,9 +104,8 @@ def plot_camera_qa(table, attribute, unit=None, lower=None, upper=None, height=2
         fig = bk.figure(plot_height=height, plot_width=width, title = title+" "+cam, tools=['reset', 'box_zoom', 'pan'])
 
         # Add HelpTool redirection to the DESI wiki.
-        fig.add_tools(HelpTool(description='See the DESI wiki for details\non Camera QA',
-                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Camera',
-                               syncable=False))
+        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Camera QA',
+                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Camera'))
 
         if attribute == 'DX' or attribute == 'DY':
             k = keys[cam]

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -84,9 +84,8 @@ def plot_camfib_focalplane(cds, attribute, cameras, percentiles={},
                         colorbar=colorbar)
 
         # Add HelpTool redirection to the DESI wiki.
-        fig.add_tools(HelpTool(description='See the DESI wiki for details\non Focalplane QA',
-                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Focalplane',
-                               syncable=False))
+        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Focalplane QA',
+                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Focalplane'))
 
         figs_list.append(fig)
         hfigs_list.append(hfig)
@@ -156,9 +155,8 @@ def plot_camfib_fot(cds, attribute, cameras, percentiles={},
 
 
         # Add HelpTool redirection to the DESI wiki.
-        fig.add_tools(HelpTool(description='See the DESI wiki for details\non Fiber positioning',
-                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Positioning',
-                               syncable=False))
+        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Fiber positioning',
+                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Positioning'))
 
         figs_list.append(fig)
 
@@ -300,9 +298,8 @@ def plot_per_fibernum(cds, attribute, cameras, titles={},
                             )
 
         # Add HelpTool redirection to the DESI wiki.
-        fig.add_tools(HelpTool(description='See the DESI wiki for details\non Cam Fiber QA',
-                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CamFiber',
-                               syncable=False))
+        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Cam Fiber QA',
+                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CamFiber'))
 
         taptool = fig.select(type=TapTool)
 


### PR DESCRIPTION
Removing an unrecognized kwarg in the new `HelpTool` that chokes bokeh at KPNO. Will result in deprecation warnings at NERSC for now.