### PR TITLE
Enable prev/next links in preproc table pages.

### DIFF
--- a/py/nightwatch/webpages/plotimage.py
+++ b/py/nightwatch/webpages/plotimage.py
@@ -80,7 +80,7 @@ def write_preproc_table_html(input_dir, night, expid, downsample, output):
 
     html_components = dict(
         plot_script=plot_script, plot_div=plot_div,
-        bokeh_version=bokeh.__version__, downsample=str(downsample), preproc=True,
+        bokeh_version=bokeh.__version__, downsample=str(downsample), preproc_table=True,
         night=night, available=available,
         current=None, expid=int(expid), zexpid='{:08d}'.format(expid),
         num_dirs=2, qatype='amp',

--- a/py/nightwatch/webpages/templates/qabase.html
+++ b/py/nightwatch/webpages/templates/qabase.html
@@ -87,6 +87,8 @@ function get_explinks(links) {
           "../../"+next_item.night+"/"+next_item.zexpid+"/qa-{{ qatype }}-"+next_item.zexpid+"-focalplane_plots.html";
         {% elif positioning %}
           "../../"+next_item.night+"/"+next_item.zexpid+"/qa-{{ qatype }}-"+next_item.zexpid+"-posacc_plots.html";
+        {% elif preproc_table %}
+          "../../"+next_item.night+"/"+next_item.zexpid+"/qa-{{ qatype }}-"+next_item.zexpid+"-preproc_table.html";
         {% else %}
           "../../"+next_item.night+"/"+next_item.zexpid+"/qa-{{ qatype }}-"+next_item.zexpid+".html";
         {% endif %}
@@ -113,6 +115,8 @@ function get_explinks(links) {
           "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-{{ qatype }}-"+prev_item.zexpid+"-focalplane_plots.html";
         {% elif positioning %}
           "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-{{ qatype }}-"+prev_item.zexpid+"-posacc_plots.html";
+        {% elif preproc_table %}
+          "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-{{ qatype }}-"+prev_item.zexpid+"-preproc_table.html";
         {% else %}
           "../../"+prev_item.night+"/"+prev_item.zexpid+"/qa-{{ qatype }}-"+prev_item.zexpid+".html";
         {% endif %}


### PR DESCRIPTION
PR to fix the broken prev/next links in the Nightwatch preproc table pages -- the pages with an array of images of the 10 cameras.

Example fix is [shown here](https://data.desi.lbl.gov/desi/users/sybenzvi/nightwatch/20220430/00132516/qa-amp-00132516-preproc_table.html).