### PR TITLE
Ncpu may22

### DIFF
--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -39,20 +39,19 @@ def get_ncpu(ncpu):
     Returns:
         number of CPU cores to use
     """
-    # Throttle to half the CPUs available.
     if ncpu is None:
         ncpu = max(1, mp.cpu_count()//2)  #- no hyperthreading
     else:
         ncpu = min(max(1, ncpu), mp.cpu_count()//2)
 
-    # Avoid grabbing many CPUs on the NERSC login nodes.
+    # Throttle to 8 cores on the NERSC login nodes.
     if ('NERSC_HOST' in os.environ) and ('SLURM_JOBID' not in os.environ):
         ncpu = min(8, ncpu)
 
-    # Throttle number of CPUs to 15 at KPNO.
+    # Throttle to 15 cores at KPNO.
     if 'HOSTNAME' in os.environ:
         if 'desi-7' == os.environ['HOSTNAME']:
-            ncpu = 15
+            ncpu = min(15, ncpu)
 
     return ncpu
 

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -30,7 +30,8 @@ def timestamp():
 
 def get_ncpu(ncpu):
     """
-    Get number of CPU cores to use, throttling to 8 for NERSC login nodes
+    Get number of CPU cores to use, throttling to 8 for NERSC login nodes and
+    15 at KPNO.
 
     Args:
         ncpu : number you would like to use, or None to auto-derive
@@ -38,11 +39,20 @@ def get_ncpu(ncpu):
     Returns:
         number of CPU cores to use
     """
+    # Throttle to half the CPUs available.
     if ncpu is None:
         ncpu = max(1, mp.cpu_count()//2)  #- no hyperthreading
+    else:
+        ncpu = min(max(1, ncpu), mp.cpu_count()//2)
 
+    # Avoid grabbing many CPUs on the NERSC login nodes.
     if ('NERSC_HOST' in os.environ) and ('SLURM_JOBID' not in os.environ):
         ncpu = min(8, ncpu)
+
+    # Throttle number of CPUs to 15 at KPNO.
+    if 'HOSTNAME' in os.environ:
+        if 'desi-7' in os.environ['HOSTNAME']:
+            npcu = 15
 
     return ncpu
 

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -51,7 +51,8 @@ def get_ncpu(ncpu):
     # Throttle to 15 cores at KPNO.
     if 'HOSTNAME' in os.environ:
         if 'desi-7' == os.environ['HOSTNAME']:
-            ncpu = min(15, ncpu)
+            if 15 <= mp.cpu_count()//2:
+                ncpu = min(15, ncpu)
 
     return ncpu
 

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -51,8 +51,8 @@ def get_ncpu(ncpu):
 
     # Throttle number of CPUs to 15 at KPNO.
     if 'HOSTNAME' in os.environ:
-        if 'desi-7' in os.environ['HOSTNAME']:
-            npcu = 15
+        if 'desi-7' == os.environ['HOSTNAME']:
+            ncpu = 15
 
     return ncpu
 

--- a/py/nightwatch/script.py
+++ b/py/nightwatch/script.py
@@ -295,6 +295,8 @@ nightwatch run --infile {infile} --outdir {outdir} {camera_options}
 
 def main_run(options=None):
     parser = argparse.ArgumentParser(usage = "{prog} run [options]")
+    parser.add_argument('-N', '--ncpu', type=int, required=False,
+        help='Number of parallel jobs to run')
     parser.add_argument("-i", "--infile", type=str, required=False,
         help="input raw data file")
     parser.add_argument("-o", "--outdir", type=str, required=True,
@@ -337,7 +339,7 @@ def main_run(options=None):
         fibermap = run.run_assemble_fibermap(args.infile, expdir)
 
         print('{} Running qproc'.format(time.strftime('%H:%M')))
-        header = run.run_qproc(args.infile, expdir, cameras=cameras)
+        header = run.run_qproc(args.infile, expdir, cameras=cameras, ncpu=args.ncpu)
 
         print('{} Running QA analysis'.format(time.strftime('%H:%M')))
         qafile = io.findfile('qa', night=night, expid=expid, basedir=tempdir)
@@ -372,6 +374,8 @@ def main_assemble_fibermap(options=None):
         
 def main_preproc(options=None):
     parser = argparse.ArgumentParser(usage = "{prog} preproc [options]")
+    parser.add_argument('-N', '--ncpu', type=int, required=False,
+        help='Number of parallel jobs to run')
     parser.add_argument("-i", "--infile", type=str, required=True,
         help="input raw data file")
     parser.add_argument("-o", "--outdir", type=str, required=True,
@@ -390,7 +394,7 @@ def main_preproc(options=None):
     else:
         cameras = None
 
-    header = run.run_preproc(args.infile, args.outdir, fibermap=args.fibermap, cameras=cameras)
+    header = run.run_preproc(args.infile, args.outdir, fibermap=args.fibermap, cameras=cameras, ncpu=args.ncpu)
     print("Done running preproc on {}; wrote outputs to {}".format(args.infile, args.outdir))
 
 def main_qproc(options=None):


### PR DESCRIPTION
Address #284 by allowing the user to specify the number of preproc and qproc jobs on the command line. The following guards are enabled:
* If the user gives <= 0 CPUs, 1 job is allocated.
* If the user specifies > half the number of available CPUs, NCPU/2 is returned.
* On the NERSC login nodes, the number of CPUs is throttled to 8 (unchanged from before).
* At KPNO, the number of CPUs is throttled to 15 (not formerly specified).