### PR TITLE
Cosmics rate 0 converted to warning for all cameras

### DIFF
--- a/py/nightwatch/threshold_files/COSMICS_RATE-20211226-ZERO.json
+++ b/py/nightwatch/threshold_files/COSMICS_RATE-20211226-ZERO.json
@@ -1,3 +1,3 @@
-{"R": {"lower_err":  0, "lower": 1, "upper": 80, "upper_err": 99.13253361717676},
+{"R": {"lower_err": -1, "lower": 1, "upper": 80, "upper_err": 99.13253361717676},
  "B": {"lower_err": -1, "lower": 1, "upper": 41.62925733, "upper_err": 50.86724008},
- "Z": {"lower_err":  0, "lower": 1, "upper": 80, "upper_err": 191.19929794384203}}
+ "Z": {"lower_err": -1, "lower": 1, "upper": 80, "upper_err": 191.19929794384203}}


### PR DESCRIPTION
The cosmics rate .json file has been updated in order to report as 'warning' in the summary tables those exposures with 0 cosmics rate (which are due to statistical fluctuations) for all the cameras.