### PR TITLE
Dead link -> temporary link to daily nightqa page.

### DIFF
--- a/py/nightwatch/webpages/templates/nights.html
+++ b/py/nightwatch/webpages/templates/nights.html
@@ -20,7 +20,9 @@
     
 <div class="container">
     <div id="button">
-        <a class="buttonstyle" href="surveyqa/summaryqa.html" target="_blank">SurveyQA</a>
+        <!-- SB (08/22): Temporarily disable the link to Nightwatch survey QA.  To avoid a dead link, point to the nightqa folder at NERSC. -->
+        <!-- <a class="buttonstyle" href="surveyqa/summaryqa.html" target="_blank">SurveyQA</a> -->
+        <a class="buttonstyle" href="https://data.desi.lbl.gov/desi/spectro/redux/daily/nightqa/" target="_blank">SurveyQA</a>
         <a class="buttonstyle" href="https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription" target="_blank">Nightwatch Help</a>
     </div>
 </div>


### PR DESCRIPTION
Cosmetic change: remove a currently dead link to the Nightwatch surveyqa time series pages and instead link to the daily nightqa plots. This is a hackish fix for part of #273. Getting the surveyqa going is the ultimate fix. But for the time being, it's better to eliminate a cryptic "data not found error" and keep #273 open.