### PR TITLE
Cut down deprecation warnings with bokeh > 2.3.0.

### DIFF
--- a/py/nightwatch/plots/amp.py
+++ b/py/nightwatch/plots/amp.py
@@ -7,11 +7,13 @@ from bokeh.models.ranges import FactorRange
 from bokeh.models import (
     LinearColorMapper, ColorBar, ColumnDataSource, OpenURL,
     NumeralTickFormatter, AdaptiveTicker,
-    TapTool, Div, HelpTool, HoverTool, Range1d, BoxAnnotation, Whisker, Band,
+    TapTool, Div, HoverTool, Range1d, BoxAnnotation, Whisker, Band,
     ResetTool, BoxZoomTool, OpenURL)
 from bokeh.models.callbacks import CustomJS
 import bokeh.palettes
 from bokeh.layouts import column, gridplot
+
+from ..plots.core import HelpTool
 
 def get_amp_colors(data, lower_err, lower, upper, upper_err):
     '''takes in per amplifier data and the acceptable threshold for that metric.
@@ -306,7 +308,7 @@ def plot_amp_qa(data, name, lower=None, upper=None, amp_keys=None, title=None, p
                      tools=[])
 
     # Use the help tool to redirect users to the DESI Nightwatch QA wiki Q&A
-    axis.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non CCD amplifier QA',
+    axis.add_tools(HelpTool(description='See the DESI wiki for details\non CCD amplifier QA',
                             redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Amplifier'))
 
     axis.line(x=labels, y=0, line_color=None)

--- a/py/nightwatch/plots/camera.py
+++ b/py/nightwatch/plots/camera.py
@@ -1,9 +1,11 @@
 import numpy as np
 import bokeh.plotting as bk
-from bokeh.models import ColumnDataSource, Whisker, BoxAnnotation, HelpTool
+from bokeh.models import ColumnDataSource, Whisker, BoxAnnotation
 from bokeh.layouts import column
 from bokeh.models.tickers import FixedTicker
 from astropy.table import Table
+
+from ..plots.core import HelpTool
 
 
 def get_qa_colors(data, lower_err, lower, upper, upper_err, basecolor='black'):
@@ -104,7 +106,7 @@ def plot_camera_qa(table, attribute, unit=None, lower=None, upper=None, height=2
         fig = bk.figure(plot_height=height, plot_width=width, title = title+" "+cam, tools=['reset', 'box_zoom', 'pan'])
 
         # Add HelpTool redirection to the DESI wiki.
-        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Camera QA',
+        fig.add_tools(HelpTool(description='See the DESI wiki for details\non Camera QA',
                                redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Camera'))
 
         if attribute == 'DX' or attribute == 'DY':

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -7,10 +7,11 @@ from astropy.table import Table
 import bokeh
 import bokeh.plotting as bk
 import bokeh.palettes as bp
-from bokeh.models import TapTool, HelpTool, OpenURL
+from bokeh.models import TapTool, OpenURL
 from bokeh.models import ColumnDataSource
 
 from ..plots.fiber import plot_fibers_focalplane, plot_fibernums
+from ..plots.core import HelpTool
 # from ..plots.core import get_colors
 
 
@@ -84,7 +85,7 @@ def plot_camfib_focalplane(cds, attribute, cameras, percentiles={},
                         colorbar=colorbar)
 
         # Add HelpTool redirection to the DESI wiki.
-        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Focalplane QA',
+        fig.add_tools(HelpTool(description='See the DESI wiki for details\non Focalplane QA',
                                redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Focalplane'))
 
         figs_list.append(fig)
@@ -155,7 +156,7 @@ def plot_camfib_fot(cds, attribute, cameras, percentiles={},
 
 
         # Add HelpTool redirection to the DESI wiki.
-        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Fiber positioning',
+        fig.add_tools(HelpTool(description='See the DESI wiki for details\non Fiber positioning',
                                redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Positioning'))
 
         figs_list.append(fig)
@@ -298,7 +299,7 @@ def plot_per_fibernum(cds, attribute, cameras, titles={},
                             )
 
         # Add HelpTool redirection to the DESI wiki.
-        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Cam Fiber QA',
+        fig.add_tools(HelpTool(description='See the DESI wiki for details\non Cam Fiber QA',
                                redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CamFiber'))
 
         taptool = fig.select(type=TapTool)

--- a/py/nightwatch/plots/core.py
+++ b/py/nightwatch/plots/core.py
@@ -2,9 +2,11 @@ import numpy as np
 import bokeh
 import bokeh.plotting as bk
 import bokeh.palettes as bp
+import bokeh
 from bokeh.transform import linear_cmap
 from bokeh.models import ColumnDataSource
 from bokeh.models import NumeralTickFormatter
+from packaging import version
 import math
 
 
@@ -33,6 +35,7 @@ def get_colors(x, palette=bp.all_palettes['RdYlBu'][11],
         raise RuntimeWarning
     ii = (n*(x-xmin) / (xmax-xmin)).astype(int).clip(0,n-1)
     return palette[ii]
+
 
 def plot_histogram(metric, num_bins=50, width=250, height=80, x_range=None, title=None,
                   palette=None, low=None, high=None):
@@ -142,8 +145,7 @@ def boxplot(q1, q2, q3, upper, lower, outliers, xpos, color='gray',
     fig.grid.grid_line_width = 2
     fig.xaxis.major_label_text_font_size="12pt"
 
-    
-    
+
 def parse_numlist(x):
     '''
     Generates a concise string output of the integers contained in x
@@ -183,3 +185,18 @@ def parse_numlist(x):
 
     s = ','.join(consecs)
     return s
+
+
+class HelpTool(bokeh.models.HelpTool):
+    """Wrapper class for the bokeh HelpTool that we can use to manage changes
+    to the bokeh API."""
+
+    def __init__(self, *args, **kwargs):
+
+        # In bokeh 2.3.0, the kwarg 'help_tooltip' was renamed 'description'.
+        islt23 = version.parse(bokeh.__version__) < version.parse('2.3.0')
+        if islt23:
+            if 'description' in kwargs:
+                kwargs['help_tooltip'] = kwargs.pop('description')
+        super().__init__(*args, **kwargs)
+

--- a/py/nightwatch/plots/plotimage.py
+++ b/py/nightwatch/plots/plotimage.py
@@ -15,10 +15,13 @@ from astropy.visualization import ZScaleInterval
 import bokeh
 import bokeh.plotting as bk
 from bokeh.layouts import layout, gridplot
-from bokeh.models import HelpTool, Label
+from bokeh.models import Label
 from bokeh.models.widgets import Panel, Tabs
 from bokeh.models.mappers import LinearColorMapper
 from bokeh.palettes import cividis, gray
+
+from ..plots.core import HelpTool
+
 
 def downsample_image(image, n):
     '''Downsample input image n x n
@@ -65,7 +68,7 @@ def plot_image(image, mask=None, mask_alpha=0.7, width=800, downsample=2, title=
                     tools='pan,box_zoom,wheel_zoom,save,reset')
 
     #- Redirect help button to DESI wiki
-    fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non CCD image QA',
+    fig.add_tools(HelpTool(description='See the DESI wiki for details\non CCD image QA',
                            redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CCDImages'))
 
     fig.image([u8img,], 0, 0, nx, ny, color_mapper=colormap)
@@ -130,7 +133,7 @@ def plot_all_images(input_files, mask_alpha=0.3, width=200, downsample=32, title
                 fig = bk.figure(width=width, height=width, tools='pan,box_zoom,wheel_zoom,reset')
 
                 #- Redirect help button to DESI wiki
-                fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non CCD image QA',
+                fig.add_tools(HelpTool(description='See the DESI wiki for details\non CCD image QA',
                                        redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CCDImages'))
 
                 #- Remove axis labels


### PR DESCRIPTION
A minor fix to manage a small change to the bokeh API. The HelpTool kwarg `help_tooltip` was renamed to `description` in bokeh 2.3.0, producing lots of deprecation warnings. This fix ensures that `help_tooltip` is used for older versions of bokeh while eliminating the warnings that fill the Nightwatch logs at NERSC.