### PR TITLE
Avoid recursive subprocess creation on OS X.

### DIFF
--- a/bin/nightwatch
+++ b/bin/nightwatch
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
-import sys
-import nightwatch.script
-sys.exit(nightwatch.script.main())
-
-
-
+if __name__ == '__main__':
+    import sys
+    import nightwatch.script
+    sys.exit(nightwatch.script.main())

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -39,9 +39,6 @@ def get_ncpu(ncpu):
     Returns:
         number of CPU cores to use
     """
-    if sys.platform == 'darwin' or sys.platform == 'win32':
-        return 1
-
     if ncpu is None:
         ncpu = max(1, mp.cpu_count()//2)  #- no hyperthreading
     else:


### PR DESCRIPTION
Add an `if __name__ == '__main__'` guard in the Nightwatch executable to avoid recursive creation of subprocesses when Nightwatch spawns parallel calls to qproc. This is required on OS X to avoid an infinite loop of spawned jobs. It does not seem to be required on Linux but should not be harmful.

Test the effect at NERSC and KPNO before merging.