### PR TITLE
Suppress deprecation warnings in bokeh >= 2.3.0.

### DIFF
--- a/py/nightwatch/plots/amp.py
+++ b/py/nightwatch/plots/amp.py
@@ -13,6 +13,9 @@ from bokeh.models.callbacks import CustomJS
 import bokeh.palettes
 from bokeh.layouts import column, gridplot
 
+from packaging import version
+_is_bokeh23 = version.parse(bokeh.__version__) >= version.parse('2.3.0')
+
 def get_amp_colors(data, lower_err, lower, upper, upper_err):
     '''takes in per amplifier data and the acceptable threshold for that metric.
     Args: 
@@ -306,8 +309,13 @@ def plot_amp_qa(data, name, lower=None, upper=None, amp_keys=None, title=None, p
                      tools=[])
 
     # Use the help tool to redirect users to the DESI Nightwatch QA wiki Q&A
-    axis.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non CCD amplifier QA',
-                            redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Amplifier'))
+    if _is_bokeh23:
+        axis.add_tools(HelpTool(description='See the DESI wiki for details\non CCD amplifier QA',
+                                redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Amplifier'))
+
+    else:
+        axis.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non CCD amplifier QA',
+                                redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Amplifier'))
 
     axis.line(x=labels, y=0, line_color=None)
     axis.grid.grid_line_color=None

--- a/py/nightwatch/plots/camera.py
+++ b/py/nightwatch/plots/camera.py
@@ -1,9 +1,14 @@
 import numpy as np
+
+import bokeh
 import bokeh.plotting as bk
 from bokeh.models import ColumnDataSource, HelpTool, Whisker, BoxAnnotation
 from bokeh.layouts import column
 from bokeh.models.tickers import FixedTicker
 from astropy.table import Table
+
+from packaging import version
+_is_bokeh23 = version.parse(bokeh.__version__) >= version.parse('2.3.0')
 
 
 def get_qa_colors(data, lower_err, lower, upper, upper_err, basecolor='black'):
@@ -104,8 +109,12 @@ def plot_camera_qa(table, attribute, unit=None, lower=None, upper=None, height=2
         fig = bk.figure(plot_height=height, plot_width=width, title = title+" "+cam, tools=['reset', 'box_zoom', 'pan'])
 
         # Add HelpTool redirection to the DESI wiki.
-        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Camera QA',
-                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Camera'))
+        if _is_bokeh23:
+            fig.add_tools(HelpTool(description='See the DESI wiki for details\non Camera QA',
+                                   redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Camera'))
+        else:
+            fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Camera QA',
+                                   redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Camera'))
 
         if attribute == 'DX' or attribute == 'DY':
             k = keys[cam]

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -10,6 +10,9 @@ import bokeh.palettes as bp
 from bokeh.models import HelpTool, TapTool, OpenURL
 from bokeh.models import ColumnDataSource
 
+from packaging import version
+_is_bokeh23 = version.parse(bokeh.__version__) >= version.parse('2.3.0')
+
 from ..plots.fiber import plot_fibers_focalplane, plot_fibernums
 # from ..plots.core import get_colors
 
@@ -84,8 +87,12 @@ def plot_camfib_focalplane(cds, attribute, cameras, percentiles={},
                         colorbar=colorbar)
 
         # Add HelpTool redirection to the DESI wiki.
-        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Focalplane QA',
-                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Focalplane'))
+        if _is_bokeh23:
+            fig.add_tools(HelpTool(description='See the DESI wiki for details\non Focalplane QA',
+                                   redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Focalplane'))
+        else:
+            fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Focalplane QA',
+                                   redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Focalplane'))
 
         figs_list.append(fig)
         hfigs_list.append(hfig)
@@ -155,8 +162,12 @@ def plot_camfib_fot(cds, attribute, cameras, percentiles={},
 
 
         # Add HelpTool redirection to the DESI wiki.
-        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Fiber positioning',
-                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Positioning'))
+        if _is_bokeh23:
+            fig.add_tools(HelpTool(description='See the DESI wiki for details\non Fiber positioning',
+                                   redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Positioning'))
+        else:
+            fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Fiber positioning',
+                                   redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Positioning'))
 
         figs_list.append(fig)
 
@@ -298,8 +309,12 @@ def plot_per_fibernum(cds, attribute, cameras, titles={},
                             )
 
         # Add HelpTool redirection to the DESI wiki.
-        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Cam Fiber QA',
-                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CamFiber'))
+        if _is_bokeh23:
+            fig.add_tools(HelpTool(description='See the DESI wiki for details\non Cam Fiber QA',
+                                   redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CamFiber'))
+        else:
+            fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Cam Fiber QA',
+                                   redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CamFiber'))
 
         taptool = fig.select(type=TapTool)
 

--- a/py/nightwatch/plots/core.py
+++ b/py/nightwatch/plots/core.py
@@ -5,7 +5,6 @@ import bokeh.palettes as bp
 from bokeh.transform import linear_cmap
 from bokeh.models import ColumnDataSource
 from bokeh.models import NumeralTickFormatter
-from packaging import version
 import math
 
 

--- a/py/nightwatch/plots/plotimage.py
+++ b/py/nightwatch/plots/plotimage.py
@@ -20,6 +20,9 @@ from bokeh.models.widgets import Panel, Tabs
 from bokeh.models.mappers import LinearColorMapper
 from bokeh.palettes import cividis, gray
 
+from packaging import version
+_is_bokeh23 = version.parse(bokeh.__version__) >= version.parse('2.3.0')
+
 
 def downsample_image(image, n):
     '''Downsample input image n x n
@@ -66,8 +69,12 @@ def plot_image(image, mask=None, mask_alpha=0.7, width=800, downsample=2, title=
                     tools='pan,box_zoom,wheel_zoom,save,reset')
 
     #- Redirect help button to DESI wiki
-    fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non CCD image QA',
-                           redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CCDImages'))
+    if _is_bokeh23:
+        fig.add_tools(HelpTool(description='See the DESI wiki for details\non CCD image QA',
+                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CCDImages'))
+    else:
+        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non CCD image QA',
+                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CCDImages'))
 
     fig.image([u8img,], 0, 0, nx, ny, color_mapper=colormap)
     if mask is not None:
@@ -131,8 +138,12 @@ def plot_all_images(input_files, mask_alpha=0.3, width=200, downsample=32, title
                 fig = bk.figure(width=width, height=width, tools='pan,box_zoom,wheel_zoom,reset')
 
                 #- Redirect help button to DESI wiki
-                fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non CCD image QA',
-                                       redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CCDImages'))
+                if _is_bokeh23:
+                    fig.add_tools(HelpTool(description='See the DESI wiki for details\non CCD image QA',
+                                           redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CCDImages'))
+                else:
+                    fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non CCD image QA',
+                                           redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#CCDImages'))
 
                 #- Remove axis labels
                 fig.xaxis.visible = False


### PR DESCRIPTION
Deal with a minor interface change in bokeh 2.3.0 that is filling the Nightwatch logs with deprecation warnings.