### PR TITLE
Clean camfiber

### DIFF
--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -42,8 +42,6 @@ def plot_camfib_focalplane(cds, attribute, cameras, percentiles={},
 
     metric = np.array(cds.data.get(attribute), copy=True)
 
-
-
     #- for hover tool
     attr_formatted_str = "@" + attribute + '{(0.00 a)}'
     tooltips = [("FIBER", "@FIBER"), ("(X, Y)", "(@X, @Y)"),
@@ -69,10 +67,8 @@ def plot_camfib_focalplane(cds, attribute, cameras, percentiles={},
         colorbar = True
 
         # adjusts for outliers on the scale of the camera
-
         in_cam = np.char.upper(np.array(cds.data['CAM']).astype(str)) == c.upper()
         cam_metric = metric[in_cam]
-
 
         pmin, pmax = np.percentile(cam_metric, (2.5, 97.5))
 

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -225,6 +225,14 @@ def plot_camfib_posacc(pcd,attribute,percentiles={},
                         fig_x_range=fig_x_range, fig_y_range=fig_y_range,
                         colorbar=True, width=400, height=400)
 
+    # Add HelpTool redirection to the DESI wiki.
+    if _is_bokeh23:
+        fig.add_tools(HelpTool(description='See the DESI wiki for details\non Fiber positioning',
+                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Positioning'))
+    else:
+        fig.add_tools(HelpTool(help_tooltip='See the DESI wiki for details\non Fiber positioning',
+                               redirect='https://desi.lbl.gov/trac/wiki/DESIOperations/NightWatch/NightWatchDescription#Positioning'))
+
     figs_list.append(fig)
     hfigs_list.append(hfig)
     return figs_list, hfigs_list

--- a/py/nightwatch/plots/camfiber.py
+++ b/py/nightwatch/plots/camfiber.py
@@ -195,7 +195,6 @@ def plot_camfib_posacc(pcd,attribute,percentiles={},
         metric = metric[(metric>0) & (metric<50)]
         pcd_data = pd.DataFrame(pcd.data)
         pcd_data = pcd_data[pcd_data['FINAL_MOVE']>0]
-        print(len(pcd_data))
         pcd = ColumnDataSource(data=pcd_data)
         title = "Final Move: Max {:.2f}um; RMS {:.2f}um; Disabled {}".format(np.max(list(metric)),np.sqrt(np.square(list(metric)).mean()), len(disabled))
         zmax = 30
@@ -203,7 +202,6 @@ def plot_camfib_posacc(pcd,attribute,percentiles={},
     attr_formatted_str = "@" + attribute + '{(0.00 a)}'
     tooltips = [("FIBER", "@FIBER"), ("(X, Y)", "(@X, @Y)"),
                 (attribute, attr_formatted_str)]
-
 
     first_x_range = bokeh.models.Range1d(-420, 420)
     first_y_range = bokeh.models.Range1d(-420, 420)
@@ -217,13 +215,13 @@ def plot_camfib_posacc(pcd,attribute,percentiles={},
 
     hist_x_range = (pmin * 0.99, zmax)
     c = '' # So not to change plot_fibers_focalplane code
-    fig, hfig = plot_fibers_focalplane(pcd, attribute,cam=c, 
+    fig, hfig = plot_fibers_focalplane(pcd, attribute, cam=c, 
                         percentile=percentiles.get(c),
-                        palette = bp.Magma256,
-                        title=title,zmin=0, zmax=zmax,
+                        palette=bp.Magma256,
+                        title=title, zmin=0, zmax=zmax,
                         tools=tools, hist_x_range=hist_x_range,
                         fig_x_range=fig_x_range, fig_y_range=fig_y_range,
-                        colorbar=True, width=400, height=400)
+                        colorbar=True, width=500, height=500)
 
     # Add HelpTool redirection to the DESI wiki.
     if _is_bokeh23:

--- a/py/nightwatch/plots/core.py
+++ b/py/nightwatch/plots/core.py
@@ -79,7 +79,7 @@ def plot_histogram(metric, num_bins=50, width=250, height=80, x_range=None, titl
     hfig.quad(top='top', bottom='bottom', left='left', right='right', color=mapper,
               alpha=0.5, source=src)
 
-    hfig.xaxis.axis_label = (' '.join(title.split(sep='_', maxsplit=2))).title()
+    hfig.xaxis.axis_label = (' '.join(title.split(sep='_', maxsplit=2))).title().replace('Snr', 'SNR')
     hfig.toolbar_location = None
     hfig.title.text_color = '#ffffff'
     hfig.yaxis.major_label_text_font_size = '0pt'

--- a/py/nightwatch/plots/fiber.py
+++ b/py/nightwatch/plots/fiber.py
@@ -101,7 +101,6 @@ def plot_fibers_focalplane(source, name, cam='',
     view_empty = CDSView(source=source, filters=[BooleanFilter(booleans_empty)])
     fig.scatter('X', 'Y', source=source, view=view_empty, color='#DDDDDD', radius=2)
 
-
     #- Adds colored outline based on camera
     if cam:
         color = camcolors.get(cam.upper())

--- a/py/nightwatch/webpages/camfiber.py
+++ b/py/nightwatch/webpages/camfiber.py
@@ -96,13 +96,15 @@ def write_fibernum_plots(data, template, outfile, header, ATTRIBUTES, CAMERAS,
 
     #- Gets the plot list for each metric in ATTRIBUTES
     fibernum_gridlist = []
-    for attr in ATTRIBUTES:
+    for attr, title in zip(ATTRIBUTES, TITLESPERCAM['B']):
         if attr in list(cds.data.keys()):
-            figs_list = plot_per_fibernum(cds, attr, CAMERAS, titles=TITLESPERCAM, tools=TOOLS)
-            fibernum_gridlist.extend(figs_list)
+            figs_list = layout(plot_per_fibernum(cds, attr, CAMERAS, titles=TITLESPERCAM, tools=TOOLS, width=800, height=150))
+            plot_title = title.replace('_', ' ').title().replace('Snr', 'SNR')
+            tab = Panel(child=figs_list, title=plot_title)
+            fibernum_gridlist.append(tab)
 
-    #- Organizes the layout of the plots
-    fn_camfiber_layout = layout(fibernum_gridlist)
+#    #- Organizes the layout of the plots
+    fn_camfiber_layout = Tabs(tabs=fibernum_gridlist)
 
     #- Writes the htmlfile
     write_file = write_htmlfile(fn_camfiber_layout, template, outfile, header)

--- a/py/nightwatch/webpages/camfiber.py
+++ b/py/nightwatch/webpages/camfiber.py
@@ -195,8 +195,10 @@ def write_posacc_plots(data, template, outfile, header,
 
             #- Add text to explain the positioner moves.
             div = Div(text="""
-                <p>Note turbulence or large (>5 um RMS) final moves.</p>
-                """, width=400, height=50)
+                <p>Select <strong>Blind</strong> or <strong>Final</strong> Move
+                tabs to view positioner accuracy.<br />
+                Note turbulence or large (>5 um RMS) final moves.</p>
+                """, width=400, height=65)
 
             #- Organize the layout of the plots
             pa_camfiber_layout = layout([

--- a/py/nightwatch/webpages/camfiber.py
+++ b/py/nightwatch/webpages/camfiber.py
@@ -103,7 +103,7 @@ def write_fibernum_plots(data, template, outfile, header, ATTRIBUTES, CAMERAS,
             tab = Panel(child=figs_list, title=plot_title)
             fibernum_gridlist.append(tab)
 
-#    #- Organizes the layout of the plots
+    #- Organizes the layout of the plots
     fn_camfiber_layout = Tabs(tabs=fibernum_gridlist)
 
     #- Writes the htmlfile
@@ -131,15 +131,17 @@ def write_focalplane_plots(data, template, outfile, header,
 
     #- Gets the plot list for each metric in ATTRIBUTES
     focalplane_gridlist = []
-    for attr in ATTRIBUTES:
+    for attr, title in zip(ATTRIBUTES, TITLESPERCAM['B']):
         if attr in list(cds.data.keys()):
-            figs_list, hfigs_list = plot_camfib_focalplane(cds, attr, CAMERAS, percentiles=PERCENTILES,
-                                     titles=TITLESPERCAM, tools=TOOLS)
+            figs_list, hfigs_list = plot_camfib_focalplane(cds, attr, CAMERAS, percentiles=PERCENTILES, titles=TITLESPERCAM, tools=TOOLS)
+            plot_title = title.replace('_', ' ').title().replace('Snr', 'SNR')
 
-            focalplane_gridlist.extend([figs_list, hfigs_list])
+            gp = gridplot([figs_list, hfigs_list], toolbar_location='right')
+            tab = Panel(child=gp, title=plot_title)
+            focalplane_gridlist.append(tab)
 
     #- Organizes the layout of the plots
-    fp_camfiber_layout = gridplot(focalplane_gridlist, toolbar_location='right')
+    fp_camfiber_layout = Tabs(tabs=focalplane_gridlist)
 
     #- Writes the htmlfile
     write_file = write_htmlfile(fp_camfiber_layout, template, outfile, header)

--- a/py/nightwatch/webpages/camfiber.py
+++ b/py/nightwatch/webpages/camfiber.py
@@ -342,11 +342,21 @@ def write_htmlfile(layout, template, outfile, header):
     exptime = header['EXPTIME']
     focalplane = 'focalplane_plots' in outfile
     positioning = 'posacc_plots' in outfile
+
+    # Fill components dictionary for use in webpages.
     components_dict = dict(
         bokeh_version=bokeh.__version__, exptime='{:.1f}'.format(exptime),
         night=night, expid=expid, zexpid='{:08d}'.format(expid),
-        obstype=obstype, program=program, qatype = 'camfiber',focalplane = focalplane,positioning = positioning,     num_dirs=2,        
+        obstype=obstype, program=program, qatype='camfiber',
+        focalplane=focalplane, positioning=positioning, num_dirs=2,
     )
+
+    # Add sky coordinates if they are present in header.
+    if obstype == 'SCIENCE':
+        if 'TILEID' in header and 'SKYRA' in header and 'SKYDEC' in header:
+            components_dict['TILEID'] = header['TILEID']
+            components_dict['SKYRA'] = header['SKYRA']
+            components_dict['SKYDEC'] = header['SKYDEC']
 
     script, div = components(layout)
     components_dict['CAMFIBER_PLOTS'] = dict(script=script, div=div)

--- a/py/nightwatch/webpages/camfiber.py
+++ b/py/nightwatch/webpages/camfiber.py
@@ -17,6 +17,7 @@ from astropy.table import Table, join, vstack, hstack
 from ..plots.camfiber import plot_camfib_focalplane, plot_per_fibernum, plot_camfib_fot, plot_camfib_posacc
 from .placeholder import handle_failed_plot
 
+
 def write_camfiber_html(outfile, data, header):
     '''
     Args:
@@ -76,6 +77,7 @@ def write_camfiber_html(outfile, data, header):
 
     return dict({})
 
+
 def write_fibernum_plots(data, template, outfile, header, ATTRIBUTES, CAMERAS,
         TITLESPERCAM, TOOLS='pan,box_select,reset'):
     '''
@@ -108,6 +110,7 @@ def write_fibernum_plots(data, template, outfile, header, ATTRIBUTES, CAMERAS,
 
     #- Writes the htmlfile
     write_file = write_htmlfile(fn_camfiber_layout, template, outfile, header)
+
 
 def write_focalplane_plots(data, template, outfile, header,
         ATTRIBUTES, CAMERAS, PERCENTILES, TITLESPERCAM,
@@ -188,6 +191,7 @@ def write_posacc_plots(data, template, outfile, header,
     #- Writes the htmlfile
     write_file = write_htmlfile(pa_camfiber_layout, template, outfile, header)
 
+
 def get_posacc_cd(header):
     '''
     Creates column data source from coordinates.fits file
@@ -249,6 +253,7 @@ def get_posacc_cd(header):
         return ColumnDataSource(data=df)
     else:
         return None
+
 
 def get_cds(data, attributes, cameras):
     '''

--- a/py/nightwatch/webpages/camfiber.py
+++ b/py/nightwatch/webpages/camfiber.py
@@ -7,11 +7,11 @@ import bokeh
 import desimodel.io
 
 from bokeh.embed import components
-from bokeh.layouts import gridplot, layout, row
+from bokeh.layouts import gridplot, layout
 
 import bokeh.plotting as bk
 from bokeh.models import ColumnDataSource
-from bokeh.models import Panel, Tabs
+from bokeh.models import Panel, Tabs, Div
 from astropy.table import Table, join, vstack, hstack
 
 from ..plots.camfiber import plot_camfib_focalplane, plot_per_fibernum, plot_camfib_fot, plot_camfib_posacc
@@ -184,18 +184,24 @@ def write_posacc_plots(data, template, outfile, header,
         pcd = get_posacc_cd(header)
         if pcd is not None:
             posplots = []
-            for attr in ['BLIND','FINAL_MOVE']:
+            for attr, plot_title in zip(['BLIND','FINAL_MOVE'], ['Blind Move', 'Final Move']):
                 figs_list,hfigs_list = plot_camfib_posacc(pcd, attr, percentiles=PERCENTILES, tools=TOOLS)
                 gp = gridplot([figs_list, hfigs_list], toolbar_location='right')
-                tab = Panel(child=gp, title=attr.title())
+                tab = Panel(child=gp, title=plot_title)
                 posplots.append(tab)
 
             #- Put positioner accuracy moves into tabs.
             posacc_camfiber_layout = Tabs(tabs=posplots)
 
+            #- Add text to explain the positioner moves.
+            div = Div(text="""
+                <p>Note turbulence or large (>5 um RMS) final moves.</p>
+                """, width=400, height=50)
+
             #- Organize the layout of the plots
             pa_camfiber_layout = layout([
                 gridplot(focalplane_gridlist, toolbar_location='right'),
+                div,
                 posacc_camfiber_layout])
 
     #- Fall-through case (no positioner plots available):

--- a/py/nightwatch/webpages/templates/fibernum.html
+++ b/py/nightwatch/webpages/templates/fibernum.html
@@ -2,4 +2,5 @@
 
 {% block plot_type %}
 <p><strong>CamFiber QA metrics vs. fiber number on the spectrograph CCDs</strong></p>
+<p>Click on a tab to view a metric. Access help with the (?) button.</p>
 {% endblock %}

--- a/py/nightwatch/webpages/templates/focalplane.html
+++ b/py/nightwatch/webpages/templates/focalplane.html
@@ -4,7 +4,11 @@
 <p><strong>CamFiber QA metrics vs. x,y location on the focal plane</strong></p>
 <p>Click on a tab to view a metric. Access help with the (?) button.</p>
 <p>QA instructions: arcs and flats include raw metrics. Science spectra include
-calibrated versions.<br />In science spectra, log unusual features such as radial
-patterns or blobs in the calibrated flux and/or SNR.</p>
-<p><a href="https://www.legacysurvey.org/viewer-desi?ra=117.1033&dec=31.1423&layer=dr9&zoom=8&desifoot=117.1240,31.1210" target="_blank">Tile position in the Legacy Survey Viewer</a></p>
+calibrated versions.<br />In science spectra, note unusual features such as radial
+patterns or blobs in the calibrated flux or SNR.</p>
+
+{% if TILEID %}
+  <p><a href="https://www.legacysurvey.org/viewer-desi?ra={{ SKYRA }}&dec={{ SKYDEC }}&layer=ls-dr9&zoom=8&desifoot={{ SKYRA }},{{ SKYDEC }}" target="_blank">Tile {{ TILEID }} position in the Legacy Survey Viewer</a>.</p>
+{% endif %}
+
 {% endblock %}

--- a/py/nightwatch/webpages/templates/focalplane.html
+++ b/py/nightwatch/webpages/templates/focalplane.html
@@ -2,4 +2,9 @@
 
 {% block plot_type %}
 <p><strong>CamFiber QA metrics vs. x,y location on the focal plane</strong></p>
+<p>Click on a tab to view a metric. Access help with the (?) button.</p>
+<p>QA instructions: arcs and flats include raw metrics. Science spectra include
+calibrated versions.<br />In science spectra, log unusual features such as radial
+patterns or blobs in the calibrated flux and/or SNR.</p>
+<p><a href="https://www.legacysurvey.org/viewer-desi?ra=117.1033&dec=31.1423&layer=dr9&zoom=8&desifoot=117.1240,31.1210" target="_blank">Tile position in the Legacy Survey Viewer</a></p>
 {% endblock %}


### PR DESCRIPTION
Tidy up the camfiber plots in tabs, so the user can quickly compare plots rather than scroll "below the fold" on the fibernum and focalplane pages.

For science tiles, add links to the Legacy Survey viewer so the user can compare features in the focal plane plots to bright objects in the survey. This addresses part of the request made in #298.

The focal plane page before the change:
![20220607_138534_before](https://user-images.githubusercontent.com/7385438/200099217-f6cdfd38-0fa5-4267-b98b-a77037e4ede7.png)

And after:
![20220607_138534_after](https://user-images.githubusercontent.com/7385438/200099220-cbc2109c-e8c5-4394-9695-fdb76fbce471.png)