### PR TITLE
fixed squashed focalplane plots in Safari

### DIFF
--- a/py/nightwatch/plots/fiber.py
+++ b/py/nightwatch/plots/fiber.py
@@ -61,7 +61,7 @@ def plot_fibers_focalplane(source, name, cam='',
     
     #adjustment for the 'all fibers in blue' error:
     if len(np.unique(cam_metric))==2:
-        pmin_full, pmax_full = np.percentile(cam_metric, (1.0,100.0))
+        pmin_full, pmax_full = np.percentile(cam_metric, (0.0,100.0))
 
 
     #- Generate colors for both plots
@@ -154,7 +154,12 @@ def plot_fibers_focalplane(source, name, cam='',
     hfig = plot_histogram(metric, title=name, width=width, x_range=hist_x_range, num_bins=50,
                          palette=mapper['transform'].palette, low=pmin_full, high=pmax_full)
     
+    if colorbar:
+        fig.aspect_ratio = 310/270
+    else:
+        fig.aspect_ratio = 250/270
     hfig.yaxis.visible = False 
+
     return fig, hfig
 
 

--- a/py/nightwatch/plots/fiber.py
+++ b/py/nightwatch/plots/fiber.py
@@ -117,15 +117,9 @@ def plot_fibers_focalplane(source, name, cam='',
     #- style visual attributes of the figure
     fig.xgrid.grid_line_color = None
     fig.ygrid.grid_line_color = None
-    fig.xaxis.major_tick_line_color = None
-    fig.xaxis.minor_tick_line_color = None
-    fig.yaxis.major_tick_line_color = None
-    fig.yaxis.minor_tick_line_color = None
     fig.outline_line_color = None
-    fig.xaxis.axis_line_color = None
-    fig.yaxis.axis_line_color = None
-    fig.xaxis.major_label_text_font_size = '0pt'
-    fig.yaxis.major_label_text_font_size = '0pt'
+    fig.xaxis.visible = False
+    fig.yaxis.visible = False
 
     taptool = fig.select(type=TapTool)
     #- Default to qcframe upon click, unless raw camfiber plot
@@ -159,7 +153,8 @@ def plot_fibers_focalplane(source, name, cam='',
             metric = np.clip(metric, zmin, zmax)
     hfig = plot_histogram(metric, title=name, width=width, x_range=hist_x_range, num_bins=50,
                          palette=mapper['transform'].palette, low=pmin_full, high=pmax_full)
-
+    
+    hfig.yaxis.visible = False 
     return fig, hfig
 
 


### PR DESCRIPTION
@jose-bermejo, this has fixed the squashing of some of the focal plane plots in Safari.

Before we commit, can you check if fixing the aspect ratio in the plots is possible? I want to make sure the bug doesn't reappear in a different form in the future.