### PR TITLE
Fiberassign qa fix

### DIFF
--- a/py/nightwatch/webpages/templates/exposures.html
+++ b/py/nightwatch/webpages/templates/exposures.html
@@ -126,20 +126,22 @@
 {% endfor %}
 
 <script>
+// Replace fiberassign URLs with local links when inside the KPNO VPN.
 let url = location.href;
+let hostIsKPNO = url.includes("kpno.noao.edu");
 
 const tilelinks = document.getElementsByClassName("tilelink");
 for (let i = 0; i < tilelinks.length; i++) {
   var tileurl = tilelinks[i].href;
-
-  // Replace fiberassign URLs with local links when using KPNO instance.
-  let hostIsKPNO = url.includes("sybenzvi");
+  
+  // If using Nightwatch @ KPNO, tile fiberassign QA links to a local folder.
   if (hostIsKPNO) {
     tileurl = tileurl.replace("https://data.desi.lbl.gov", "http://desi-7.kpno.noao.edu:8001");
     tilelinks[i].href = tileurl;
   }
+  // Outside the VPN, print warning about delays in fiberassign data transfers.
   else {
-    tilelinks[i].title = "Fiberassign QA takes 24 hr to appear at NERSC.";
+    tilelinks[i].title = "Fiberassign QA may take >24 hr to appear at NERSC.";
   }
 }
 </script>

--- a/py/nightwatch/webpages/templates/exposures.html
+++ b/py/nightwatch/webpages/templates/exposures.html
@@ -67,7 +67,7 @@
 {% else %}
     <td><a href="{{ exp.link }}">{{ exp.expid }}</a></td>
     {% if exp.TILEID_LINK != "na" %}
-      <td><a href="{{ exp.TILEID_LINK }}">{{ exp.TILEID }}</a></td>
+      <td><a href="{{ exp.TILEID_LINK }}" target="_blank" class="tilelink">{{ exp.TILEID }}</a></td>
     {% else %}
       <td>{{ exp.TILEID }}</td>
     {% endif %}
@@ -124,5 +124,24 @@
     
 </tr>
 {% endfor %}
+
+<script>
+let url = location.href;
+
+const tilelinks = document.getElementsByClassName("tilelink");
+for (let i = 0; i < tilelinks.length; i++) {
+  var tileurl = tilelinks[i].href;
+
+  // Replace fiberassign URLs with local links when using KPNO instance.
+  let hostIsKPNO = url.includes("sybenzvi");
+  if (hostIsKPNO) {
+    tileurl = tileurl.replace("https://data.desi.lbl.gov", "http://desi-7.kpno.noao.edu:8001");
+    tilelinks[i].href = tileurl;
+  }
+  else {
+    tilelinks[i].title = "Fiberassign QA takes 24 hr to appear at NERSC.";
+  }
+}
+</script>
 
 {% endblock %}


### PR DESCRIPTION
This PR redirects the fiberassign tile QA links from the standard location at NERSC to a location at KPNO. It will only affect users viewing exposures using the KPNO Nightwatch instance in the VPN. It will address #238 and related tickets, where users have complained that they cannot view fiberassign QA during observing work.

Before merging, an accessible location for fiberassign PNG files at KPNO needs to be fixed.