### PR TITLE
Spectra cleanup nov 22

### DIFF
--- a/py/nightwatch/plots/spectra.py
+++ b/py/nightwatch/plots/spectra.py
@@ -8,6 +8,7 @@ import random, os, sys, re
 
 from .. import io
 
+
 def downsample(data, n, agg=np.mean):
     '''
     Produces downsampled data of data
@@ -23,14 +24,8 @@ def downsample(data, n, agg=np.mean):
     '''
     length = len(data)
     resultx = [agg(data[j:(j+n)]) if (j+n <= length) else agg(data[j:length]) for j in range(0, length, n)]
-#     for j in range(0, length, n):
-#         if (j+n <= length):
-#             samplex = data[j:(j+n)]
-#             resultx += [agg(samplex)]
-#         else:
-#             samplex = data[j:length]
-#             resultx += [agg(samplex)]
     return resultx
+
 
 def plot_spectra_spectro(data, expid_num, frame, n, num_fibs=3, height=220, width=240):
     '''
@@ -158,14 +153,14 @@ def plot_spectra_spectro(data, expid_num, frame, n, num_fibs=3, height=220, widt
     grid = gridplot([p1, p2], sizing_mode="fixed")
     return grid
 
+
 def plot_spectra_objtype(data, expid_num, frame, n, num_fibs=5, height=500, width=1000):
     '''
-    Produces a gridplot of different spectra plots, each displaying a number of randomly
-    selected fibers that correspond to each unique OBJTYPE.
+    Produces a gridplot of different spectra plots, each displaying a number of randomly selected fibers that correspond to each unique OBJTYPE.
 
     Args:
-        data: night directory that contains the expid we want to process spectra for
-        expid_num: string or int of the expid we want to process spectra for
+        data: night directory that contains the expid we want to process.
+        expid_num: string or int of the expid we want to process spectra.
         frame: filename header to look for ("qframe" or "qcframe")
         n: int of downsample size
 
@@ -256,6 +251,7 @@ def plot_spectra_objtype(data, expid_num, frame, n, num_fibs=5, height=500, widt
         gridlist += [[fig]]
     return gridplot(gridlist, sizing_mode="fixed")
 
+
 def lister(string):
     '''
     Produces a list of fibers from translating the string input
@@ -282,17 +278,17 @@ def lister(string):
     except:
         return None
 
+
 def plot_spectra_input(datadir, expid_num, frame, n, select_string, height=500, width=1000):
     '''
     Produces plot displaying the specific fibers requested.
 
     Args:
-        datadir: night directory that contains the expid we want to process spectra for
+        datadir: night directory that contains the expid we want to process
         expid_num: string or int of the expid we want to process spectra for
         frame: filename header to look for ("qframe" or "qcframe")
         n: int of downsample size
-        select_string: string that requests specific fibers ("1, 3-5" corresponds
-            to fibers 1, 3, 5)
+        select_string: string that requests specific fibers ("1, 3-5" corresponds to fibers 1, 3, 5)
 
     Options:
         height: height of the plot

--- a/py/nightwatch/plots/spectra.py
+++ b/py/nightwatch/plots/spectra.py
@@ -363,7 +363,7 @@ def plot_spectra_input(datadir, expid_num, frame, n, select_string, height=500, 
                 fig.line("wave", "flux", source=source, alpha=0.5, color=colors[cam])
 
     # Open a link to the Legacy Survey when the user taps the spectrum.
-    url = "https://www.legacysurvey.org/viewer-desi?ra=@ra&dec=@dec&layer=ls-dr9&zoom=15"
+    url = "https://www.legacysurvey.org/viewer-desi?ra=@ra&dec=@dec&layer=ls-dr9&zoom=15&mark=@ra,@dec"
     taptool = fig.select(type=TapTool)
     taptool.callback = OpenURL(url=url)
 

--- a/py/nightwatch/webpages/spectra.py
+++ b/py/nightwatch/webpages/spectra.py
@@ -13,18 +13,18 @@ def get_spectra_html(data, night, expid, view, frame, downsample_str, select_str
     the page depends on the provided view.
 
     Args:
-        data: night directory that contains the expid we want to process spectra for
-        night : string or int of the night we want to process spectra for
-        expid: string or int of the expid we want to process spectra for
+        data: night directory that contains the expid we want to process.
+        night : string or int of the night we want to process spectra.
+        expid: string or int of the expid we want to process spectra.
         view: must be either "spectrograph", "objtype", "input".
             "spectrograph":
-                generates 10 different plots corresponding to each spectrograph
+                generate 10 different plots corresponding to each spectrograph
             "objtype":
-                generates different plots corresponding to each different objtype
+                generate different plots corresponding to each different objtype
             "input":
                 generates different plots corresponding to the user's input
         frame: filename header to look for ("qframe" or "qcframe")
-        downsample_str: string corresponding to downsample, structured like "4x".
+        downsample_str: string corresponding to downsample, e.g., "4x".
             if None, assumes "4x"
 
     Options:

--- a/py/nightwatch/webpages/templates/spectra.html
+++ b/py/nightwatch/webpages/templates/spectra.html
@@ -32,8 +32,8 @@ header {
 
 <label> Frame:
   <form id="frame">
-    <input type="radio" name="frame" value="qframe" {% if frame=="qframe"%} checked="yes" {% endif%}/> qframe<br />
-    <input type="radio" name="frame" value="qcframe"  {% if frame=="qcframe"%} checked="yes" {% endif%}/> qcframe<br />
+    <input type="radio" name="frame" value="qframe" {% if frame=="qframe"%} checked="yes" {% endif%}/> <strong>qframe</strong> (uncalibrated "raw" spectra)<br />
+    <input type="radio" name="frame" value="qcframe"  {% if frame=="qcframe"%} checked="yes" {% endif%}/> <strong>qcframe</strong> (calibrated spectra) <br />
   </form>
 </label>
 
@@ -77,7 +77,7 @@ for (var i = 0, length = radios.length; i < length; i++)
 
 <button onclick='
   window.open("../../{% if frame=="qframe" %}qcframe{% else %}qframe{% endif %}/{{ downsample | safe }}x", "_top")
-'>Generate with {% if frame=="qframe" %}qcframe{% else %}qframe{% endif %} (if avaliable)
+'>Generate with {% if frame=="qframe" %}calibrated spectra{% else %}uncalibrated spectra{% endif %} (if avaliable)
 </button>
 
 {% endif %}

--- a/py/nightwatch/webpages/templates/spectra.html
+++ b/py/nightwatch/webpages/templates/spectra.html
@@ -22,6 +22,11 @@ header {
   </font>
 </header>
 
+  <!-- User instructions that appear after a spectrum has been plotted. -->
+  <p>Hover over spectra for detailed information.<br />Left-click on a spectrum to view the object in the <a href="https://www.legacysurvey.org/viewer-desi" target="_blank">Legacy Survey Viewer</a>.</p>
+
+  <p>Access help with the (?) button.</p>
+
     <div class=flex-item>{{ spectra.script | safe }} {{ spectra.div | safe }}</div>
 {% endif %}
 <br>


### PR DESCRIPTION
PR to address #211. After plotting a spectrum using the input form, the user can left-click on the spectrum to open a new tab showing the object in the Legacy Survey viewer.

Unfortunately, bokeh offers limited granularity in enabling/disabling this feature for calibration spectra. For these cases, and cases where the fibermap is unavailable for some reason, left clicking will open a Legacy Survey page at RA=0, Dec=0.