### PR TITLE
Address broken SurveyQA link in exposure tables.

### DIFF
--- a/py/nightwatch/webpages/templates/exposures.html
+++ b/py/nightwatch/webpages/templates/exposures.html
@@ -6,7 +6,8 @@
 </ul>
 <ul class="navigationbar">
   <li style="float:left"><a href="../nights.html">Calendar</a></li>
-  <li style="float:left"><a href="../surveyqa/nightqa-{{ night }}.html">SurveyQA</a></li>
+  <!-- <li style="float:left"><a href="../surveyqa/nightqa-{{ night }}.html">SurveyQA</a></li> -->
+  <li style="float:left"><a href="https://data.desi.lbl.gov/desi/spectro/redux/daily/nightqa/">SurveyQA</a></li>
   <li><a id="next">next</a></li>
   <li><a id="prev">prev</a></li>
   <li><a href="../qa-lastexp.html">latest</a></li>


### PR DESCRIPTION
PR to fix remaining broken SurveyQA links in #273. The links on the Nightwatch landing page and the exposure lists now point to the nightqa pages at NERSC.

It could definitely be desirable to have a realtime SurveyQA page within Nightwatch with, e.g., a sky plot of tiles observed in a given evening. That should be the subject of a separate ticket.