### PR TITLE
Add spectrograph labels to CCD QA index page.

### DIFF
--- a/py/nightwatch/plots/plotimage.py
+++ b/py/nightwatch/plots/plotimage.py
@@ -108,8 +108,9 @@ def plot_all_images(input_files, mask_alpha=0.3, width=200, downsample=32, title
             #- Check that the input file exists for this camera + spectrograph.
             if input_file:
                 with fits.open(input_file[0]) as hdul:
-                    image = hdul[0].data
-                    mask  = hdul[2].data
+                    image  = hdul[0].data
+                    imghdr = hdul[0].header
+                    mask   = hdul[2].data
 
                 ny, nx = image.shape
                 image2 = downsample_image(image, downsample)
@@ -153,6 +154,12 @@ def plot_all_images(input_files, mask_alpha=0.3, width=200, downsample=32, title
                 if mask is not None:
                     fig.image([u8mask,], 0, 0, nx, ny, color_mapper=yellowmap)
 
+                # Label spectrograph ID
+                label = Label(x=10, y=160, x_units='screen', y_units='screen',
+                              text=f'SM{imghdr["SPECID"]}', text_color='#00ffff', text_font_style='bold')
+                fig.add_layout(label)
+
+                # Label camera
                 label = Label(x=10, y=10, x_units='screen', y_units='screen',
                               text=f'{cam}{j}', text_color='#00ff00', text_font_style='bold')
                 fig.add_layout(label)


### PR DESCRIPTION
PR to fix #143 (picking some low-hanging fruit), this adds the spectrograph ID to the CCD index page. An example is shown below; SM ID is in the upper left and camera ID is in the lower left.

![Screen Shot 2022-11-21 at 12 41 42 AM](https://user-images.githubusercontent.com/7385438/202974358-10c9edc8-e851-4001-adda-43ee416c835c.png)
