### PR TITLE
Fix for nightwatch monitor on desi-7.

### DIFF
--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -221,12 +221,14 @@ def run_assemble_fibermap(rawfile, outdir):
             log.info('Creating {}'.format(outdir))
             os.makedirs(outdir, exist_ok=True)
 
-        # Environment override required at KPNO.
-        new_env = dict(os.environ)
+        # Environment variable DESI_SPECTRO_DATA required if not defined.
+        new_env = os.environ
         if 'DESI_SPECTRO_DATA' not in new_env:
-            if 'HOSTNAME' in new_env:
-                if 'desi-7' == new_env['HOSTNAME']:
-                    new_env['DESI_SPECTRO_DATA'] = '/data/dts/exposures/raw'
+            subfolder = f'{night}/{expid:08d}/{os.path.basename(rawfile)}'
+            rawdir = rawfile.replace(subfolder, '')
+            if os.path.isdir(rawdir):
+                new_env.update({'DESI_SPECTRO_DATA' : rawdir})
+                log.info(f'Updated DESI_SPECTRO_DATA to {new_env["DESI_SPECTRO_DATA"]}')
 
         fibermap = os.path.join(outdir, 'fibermap-{:08d}.fits'.format(expid))
         cmd = f'assemble_fibermap -n {night} -e {expid} -o {fibermap} --overwrite'


### PR DESCRIPTION
PR to _finally_ get targeting information into Nightwatch at KPNO. When running as a daemon, `nightwatch monitor` does not have access to the hostname `desi-7`, so this fix ensures that `assemble_fibermap` runs properly in the monitor even when the environment variable `DESI_SPECTRO_DATA` is undefined. It is a reasonably robust fix in that it does not hardcode paths at KPNO, and will fail elegantly if the fibermap creation does not work.