### PR TITLE
Targetype dec 2022

### DIFF
--- a/py/nightwatch/plots/spectra.py
+++ b/py/nightwatch/plots/spectra.py
@@ -8,6 +8,8 @@ from bokeh.models import BoxAnnotation, ColumnDataSource, Range1d, Title, HoverT
 import numpy as np
 import random, os, sys, re
 
+from desitarget.targets import desi_mask
+
 from .. import io
 
 from packaging import version
@@ -344,12 +346,28 @@ def plot_spectra_input(datadir, expid_num, frame, n, select_string, height=500, 
             assert len(spectrofibers) == len(indexes)
 
             for i, ifiber in zip(indexes, spectrofibers):
+                # Extract flux and wavelength.
                 dwavelength = downsample(wavelength[i], n)
                 dflux = downsample(flux[i], n)
                 length = len(dwavelength)
+
+                # Extract object type (TGT or SKY) and bitmask info.
                 objtype = fibermap['OBJTYPE'][i]
+                desitgt = fibermap['DESI_TARGET'][i]
+                desinms = desi_mask.names(desitgt)
+                tgtname = desinms[0] if len(desinms) > 0 else 'None'
+
+                if not objtype:
+                    objtype = 'None'
+                else:
+                    if 'TGT' in objtype:
+                        objtype = f'{objtype}: {tgtname}'
+
+                # Get sky coordinates of the spectrum.
                 ra  = fibermap['TARGET_RA'][i]
                 dec = fibermap['TARGET_DEC'][i]
+
+                # Create a column data source used for mouseover info.
                 source = ColumnDataSource(data=dict(
                             fiber = [ifiber]*length,
                             cam = [cam]*length,

--- a/py/nightwatch/plots/spectra.py
+++ b/py/nightwatch/plots/spectra.py
@@ -85,22 +85,22 @@ def plot_spectra_spectro(data, expid_num, frame, n, num_fibs=3, height=220, widt
         colors = {}
         fib = []
         try:
-            fib += [list(fits.getdata(os.path.join(data, expid, '{}-b{}-{}.fits'.format(frame, spectro, expid)), 5)["FIBER"])]
-            colors["B"] = "steelblue"
+            fib += [list(fits.getdata(os.path.join(data, expid, '{}-b{}-{}.fits'.format(frame, spectro, expid)), extname='FIBERMAP')['FIBER'])]
+            colors['B'] = 'steelblue'
         except:
-            print("could not find {}".format(os.path.join(data, expid, '{}-b{}-{}.fits'.format(frame, spectro, expid))), file=sys.stderr)
+            print('could not find {}'.format(os.path.join(data, expid, '{}-b{}-{}.fits'.format(frame, spectro, expid))), file=sys.stderr)
 
         try:
-            fib += [list(fits.getdata(os.path.join(data, expid, '{}-r{}-{}.fits'.format(frame, spectro, expid)), 5)["FIBER"])]
-            colors["R"] = "crimson"
+            fib += [list(fits.getdata(os.path.join(data, expid, '{}-r{}-{}.fits'.format(frame, spectro, expid)), extname='FIBERMAP')['FIBER'])]
+            colors['R'] = 'crimson'
         except:
-            print("could not find {}".format(os.path.join(data, expid, '{}-r{}-{}.fits'.format(frame, spectro, expid))), file=sys.stderr)
+            print('could not find {}'.format(os.path.join(data, expid, '{}-r{}-{}.fits'.format(frame, spectro, expid))), file=sys.stderr)
 
         try:
-            fib += [list(fits.getdata(os.path.join(data, expid, '{}-z{}-{}.fits'.format(frame, spectro, expid)), 5)["FIBER"])]
-            colors["Z"] = "forestgreen"
+            fib += [list(fits.getdata(os.path.join(data, expid, '{}-z{}-{}.fits'.format(frame, spectro, expid)), extname='FIBERMAP')['FIBER'])]
+            colors['Z'] = 'forestgreen'
         except:
-            print("could not find {}".format(os.path.join(data, expid, '{}-b{}-{}.fits'.format(frame, spectro, expid))), file=sys.stderr)
+            print('could not find {}'.format(os.path.join(data, expid, '{}-b{}-{}.fits'.format(frame, spectro, expid))), file=sys.stderr)
 
         if (len(colors) == 0 and spectro == np.max(spectrorange) and first is None):
             print("no supported {}-*.fits files".format(frame))
@@ -122,13 +122,13 @@ def plot_spectra_spectro(data, expid_num, frame, n, num_fibs=3, height=220, widt
         # fig.add_layout(Title(text= "Downsample: {}".format(n), text_font_style="italic"), 'above')
         # fig.add_layout(Title(text= "Fibers: {}".format(common), text_font_style="italic"), 'above')
         # fig.add_layout(Title(text="Spectro: {}".format(spectro), text_font_size="12pt"), 'above')
-        title = "sp{} fibers {}".format(spectro, ", ".join(map(str, common)))
-        fig.add_layout(Title(text=title, text_font_style="italic"), 'above')
+        title = 'sp{} fibers {}'.format(spectro, ', '.join(map(str, common)))
+        fig.add_layout(Title(text=title, text_font_style='italic'), 'above')
         tooltips = tooltips=[
-            ("Fiber", "@fiber"),
-            ("Cam", "@cam"),
-            ("Wavelength", "@wave"),
-            ("Flux", "@flux")
+            ('Fiber', '@fiber'),
+            ('Cam', '@cam'),
+            ('Wavelength', '@wave'),
+            ('Flux', '@flux')
         ]
 
         hover = HoverTool(
@@ -142,8 +142,8 @@ def plot_spectra_spectro(data, expid_num, frame, n, num_fibs=3, height=220, widt
 
         flux_total = []
         for cam in colors:
-            wavelength = fits.getdata(os.path.join(data, expid, '{}-{}{}-{}.fits'.format(frame, cam.lower(), spectro, expid)), "WAVELENGTH")
-            flux = fits.getdata(os.path.join(data, expid, '{}-{}{}-{}.fits'.format(frame, cam.lower(), spectro, expid)), "FLUX")
+            wavelength = fits.getdata(os.path.join(data, expid, '{}-{}{}-{}.fits'.format(frame, cam.lower(), spectro, expid)), 'WAVELENGTH')
+            flux = fits.getdata(os.path.join(data, expid, '{}-{}{}-{}.fits'.format(frame, cam.lower(), spectro, expid)), 'FLUX')
             for i in indexes:
                 dwavelength = downsample(wavelength[i], n)
                 dflux = downsample(flux[i], n)
@@ -156,7 +156,7 @@ def plot_spectra_spectro(data, expid_num, frame, n, num_fibs=3, height=220, widt
                             wave = dwavelength,
                             flux = dflux,
                         ))
-                fig.line("wave", "flux", source=source, alpha=0.5, color=colors[cam])
+                fig.line('wave', 'flux', source=source, alpha=0.5, color=colors[cam])
 
         if first is None:
             if len(colors) == 3:
@@ -181,7 +181,7 @@ def plot_spectra_spectro(data, expid_num, frame, n, num_fibs=3, height=220, widt
         fig.x_range=first.x_range
         fig.y_range=first.y_range
 
-    grid = gridplot([p1, p2], sizing_mode="fixed")
+    grid = gridplot([p1, p2], sizing_mode='fixed')
     return grid
 
 
@@ -214,22 +214,22 @@ def plot_spectra_objtype(data, expid_num, frame, n, num_fibs=5, height=500, widt
     spectros = random.choices(list(set(spectr)), k=num_fibs)
 
     gridlist = []
-    unique_objs = list(set(fits.getdata(os.path.join(data, expid, qframes[0]), 5)["OBJTYPE"]))
+    unique_objs = list(set(fits.getdata(os.path.join(data, expid, qframes[0]), extname='FIBERMAP')["OBJTYPE"]))
     unique_objs.sort()
     for obj in unique_objs:
         fig=bk.figure(plot_height = height, plot_width = width)
         com = []
         first = True
         for spectro in spectros:
-            r_fib = fits.getdata(os.path.join(data, expid, '{}-r{}-{}.fits'.format(frame, spectro, expid)), 5)
+            r_fib = fits.getdata(os.path.join(data, expid, '{}-r{}-{}.fits'.format(frame, spectro, expid)), extname='FIBERMAP')
             bool_array = r_fib["OBJTYPE"] == obj
             r_fib = r_fib["FIBER"]
             r_fib = [r_fib[i] if bool_array[i] else None for i in range(len(r_fib))]
 
-            b_fib = fits.getdata(os.path.join(data, expid, '{}-b{}-{}.fits'.format(frame, spectro, expid)), 5)
+            b_fib = fits.getdata(os.path.join(data, expid, '{}-b{}-{}.fits'.format(frame, spectro, expid)), extname='FIBERMAP')
             b_fib = b_fib[b_fib["OBJTYPE"] == obj]["FIBER"]
 
-            z_fib = fits.getdata(os.path.join(data, expid, '{}-z{}-{}.fits'.format(frame, spectro, expid)), 5)
+            z_fib = fits.getdata(os.path.join(data, expid, '{}-z{}-{}.fits'.format(frame, spectro, expid)), extname='FIBERMAP')
             z_fib = z_fib[z_fib["OBJTYPE"] == obj]["FIBER"]
 
             common = list(set(r_fib).intersection(b_fib).intersection(z_fib))

--- a/py/nightwatch/plots/spectra.py
+++ b/py/nightwatch/plots/spectra.py
@@ -1,4 +1,3 @@
-from astropy.io import fits
 import fitsio
 
 import bokeh
@@ -88,22 +87,22 @@ def plot_spectra_spectro(data, expid_num, frame, n, num_fibs=3, height=220, widt
         colors = {}
         fib = []
         try:
-            fib += [list(fits.getdata(os.path.join(data, expid, '{}-b{}-{}.fits'.format(frame, spectro, expid)), extname='FIBERMAP')['FIBER'])]
+            fib += [list(fitsio.read(os.path.join(data, expid, f'{frame}-b{spectro}-{expid}.fits'), columns=['FIBER'], ext='FIBERMAP'))]
             colors['B'] = 'steelblue'
         except:
-            print('could not find {}'.format(os.path.join(data, expid, '{}-b{}-{}.fits'.format(frame, spectro, expid))), file=sys.stderr)
+            print('could not find {}'.format(os.path.join(data, expid, f'{frame}-b{spectro}-{expid}.fits')), file=sys.stderr)
 
         try:
-            fib += [list(fits.getdata(os.path.join(data, expid, '{}-r{}-{}.fits'.format(frame, spectro, expid)), extname='FIBERMAP')['FIBER'])]
+            fib += [list(fitsio.read(os.path.join(data, expid, f'{frame}-r{spectro}-{expid}.fits'), columns=['FIBER'], ext='FIBERMAP'))]
             colors['R'] = 'crimson'
         except:
-            print('could not find {}'.format(os.path.join(data, expid, '{}-r{}-{}.fits'.format(frame, spectro, expid))), file=sys.stderr)
+            print('could not find {}'.format(os.path.join(data, expid, f'{frame}-r{spectro}-{expid}.fits')), file=sys.stderr)
 
         try:
-            fib += [list(fits.getdata(os.path.join(data, expid, '{}-z{}-{}.fits'.format(frame, spectro, expid)), extname='FIBERMAP')['FIBER'])]
+            fib += [list(fitsio.read(os.path.join(data, expid, f'{frame}-z{spectro}-{expid}.fits'), columns=['FIBER'], ext='FIBERMAP'))]
             colors['Z'] = 'forestgreen'
         except:
-            print('could not find {}'.format(os.path.join(data, expid, '{}-b{}-{}.fits'.format(frame, spectro, expid))), file=sys.stderr)
+            print('could not find {}'.format(os.path.join(data, expid, f'{frame}-z{spectro}-{expid}.fits')), file=sys.stderr)
 
         if (len(colors) == 0 and spectro == np.max(spectrorange) and first is None):
             print("no supported {}-*.fits files".format(frame))
@@ -145,8 +144,8 @@ def plot_spectra_spectro(data, expid_num, frame, n, num_fibs=3, height=220, widt
 
         flux_total = []
         for cam in colors:
-            wavelength = fits.getdata(os.path.join(data, expid, '{}-{}{}-{}.fits'.format(frame, cam.lower(), spectro, expid)), 'WAVELENGTH')
-            flux = fits.getdata(os.path.join(data, expid, '{}-{}{}-{}.fits'.format(frame, cam.lower(), spectro, expid)), 'FLUX')
+            wavelength = fitsio.read(os.path.join(data, expid, f'{frame}-{came.lower()}{spectro}-{expid}.fits'), ext='WAVELENGTH')
+            flux = fitsio.read(os.path.join(data, expid, f'{frame}-{came.lower()}{spectro}-{expid}.fits'), ext='FLUX')
             for i in indexes:
                 dwavelength = downsample(wavelength[i], n)
                 dflux = downsample(flux[i], n)
@@ -231,7 +230,8 @@ def plot_spectra_objtype(data, expid_num, frame, n, num_fibs=5, height=500, widt
         else:
             unique_nms = np.unique(np.concatenate([unique_nms, objnames]))
 
-    unique_objs = list(set(fits.getdata(os.path.join(data, expid, qframes[0]), extname='FIBERMAP')["OBJTYPE"]))
+#    unique_objs = list(set(fits.getdata(os.path.join(data, expid, qframes[0]), extname='FIBERMAP')["OBJTYPE"]))
+    unique_objs = list(set(fitsio.read(qframes[0], columns=['OBJTYPE'], ext='FIBERMAP')['OBJTYPE']))
     unique_objs.sort()
     for obj in unique_objs:
 #    for nm in unique_nms:
@@ -266,8 +266,8 @@ def plot_spectra_objtype(data, expid_num, frame, n, num_fibs=5, height=500, widt
             for cam in colors:
                 if indexes == []:
                     continue
-                wavelength = fits.getdata(os.path.join(data, expid, '{}-{}{}-{}.fits'.format(frame, cam.lower(), spectro, expid)), "WAVELENGTH")
-                flux = fits.getdata(os.path.join(data, expid, '{}-{}{}-{}.fits'.format(frame, cam.lower(), spectro, expid)), "FLUX")
+                wavelength = fitsio.read(os.path.join(data, expid, f'{frame}-{cam.lower()}{spectro}-{expid}.fits'), ext='WAVELENGTH')
+                flux = fitsio.read(os.path.join(data, expid, f'{frame}-{cam.lower()}{spectro}-{expid}.fits'), ext='FLUX')
                 for i in indexes:
                     dwavelength = downsample(wavelength[i], n)
                     dflux = downsample(flux[i], n)
@@ -280,19 +280,19 @@ def plot_spectra_objtype(data, expid_num, frame, n, num_fibs=5, height=500, widt
                                 wave = dwavelength,
                                 flux = dflux
                             ))
-                    fig.line("wave", "flux", source=source, alpha=0.5, color=colors[cam])
+                    fig.line('wave', 'flux', source=source, alpha=0.5, color=colors[cam])
             first = False
 
         #grid = gridplot(p1, p2)
-        fig.add_layout(Title(text= "Downsample: {}".format(n), text_font_style="italic"), 'above')
-        fig.add_layout(Title(text= "Fibers: {}".format(com), text_font_style="italic"), 'above')
-        fig.add_layout(Title(text= "OBJTYPE: {}".format(obj), text_font_size="16pt"), 'above')
+        fig.add_layout(Title(text= f'Downsample: {n}', text_font_style='italic'), 'above')
+        fig.add_layout(Title(text= f'Fibers: {com}', text_font_style='italic'), 'above')
+        fig.add_layout(Title(text= f'OBJTYPE: {obj}', text_font_size='16pt'), 'above')
 
         tooltips = tooltips=[
-            ("Fiber", "@fiber"),
-            ("Cam", "@cam"),
-            ("Wavelength", "@wave"),
-            ("Flux", "@flux")
+            ('Fiber', '@fiber'),
+            ('Cam', '@cam'),
+            ('Wavelength', '@wave'),
+            ('Flux', '@flux')
         ]
 
         hover = HoverTool(
@@ -304,7 +304,7 @@ def plot_spectra_objtype(data, expid_num, frame, n, num_fibs=5, height=500, widt
         upper = int(np.percentile(flux_total, 99.99))
         fig.y_range = Range1d(int(-0.02*upper), upper)
         gridlist += [[fig]]
-    return gridplot(gridlist, sizing_mode="fixed")
+    return gridplot(gridlist, sizing_mode='fixed')
 
 
 def lister(string):
@@ -385,10 +385,10 @@ def plot_spectra_input(datadir, expid_num, frame, n, select_string, height=500, 
                 print(f"WARNING: missing {framefile}")
                 continue
 
-            fibermap = fits.getdata(framefile, 'FIBERMAP')
+            fibermap = fitsio.read(framefile, ext='FIBERMAP')
 
-            wavelength = fits.getdata(framefile, "WAVELENGTH")
-            flux = fits.getdata(framefile, "FLUX")
+            wavelength = fitsio.read(framefile, ext='WAVELENGTH')
+            flux = fitsio.read(framefile, ext='FLUX')
             spectrofibers = fibergroups[spectro]
             indexes = np.where(np.in1d(fibermap['FIBER'], spectrofibers))[0]
             assert len(spectrofibers) == len(indexes)

--- a/py/nightwatch/plots/spectra.py
+++ b/py/nightwatch/plots/spectra.py
@@ -221,7 +221,16 @@ def plot_spectra_objtype(data, expid_num, frame, n, num_fibs=5, height=500, widt
 
     gridlist = []
 
-    # Set up a unique list of object names.
+    # Set up a unique list of object names (quickly sort through all qframes).
+    unique_nms = None
+    for qframe in qframes:
+        fmap = fitsio.read(qframe, columns=['OBJTYPE','DESI_TARGET'], ext='FIBERMAP')
+        objnames = get_spectrum_objname(fmap['OBJTYPE'], fmap['DESI_TARGET'])
+        if unique_nms is None:
+            unique_nms = np.unique(objnames)
+        else:
+            unique_nms = np.unique(np.concatenate([unique_nms, objnames]))
+
 #    fmap = fits.getdata(os.path.join(data, expid, qframes[0]), extname='FIBERMAP')
 #    unique_nms = list(set([get_spectrum_objname(o, d) \
 #                      for o,d in zip(fmap['OBJTYPE'], fmap['DESI_TARGET'])]))

--- a/py/nightwatch/plots/spectra.py
+++ b/py/nightwatch/plots/spectra.py
@@ -231,11 +231,6 @@ def plot_spectra_objtype(data, expid_num, frame, n, num_fibs=5, height=500, widt
         else:
             unique_nms = np.unique(np.concatenate([unique_nms, objnames]))
 
-#    fmap = fits.getdata(os.path.join(data, expid, qframes[0]), extname='FIBERMAP')
-#    unique_nms = list(set([get_spectrum_objname(o, d) \
-#                      for o,d in zip(fmap['OBJTYPE'], fmap['DESI_TARGET'])]))
-#    unique_nms.sort()
-
     unique_objs = list(set(fits.getdata(os.path.join(data, expid, qframes[0]), extname='FIBERMAP')["OBJTYPE"]))
     unique_objs.sort()
     for obj in unique_objs:
@@ -244,18 +239,20 @@ def plot_spectra_objtype(data, expid_num, frame, n, num_fibs=5, height=500, widt
         com = []
         first = True
         for spectro in spectros:
-            filename = os.path.join(data, expid, '{}-r{}-{}.fits'.format(frame, spectro, expid))
-            r_fib = fits.getdata(filename, extname='FIBERMAP')
+            filename = os.path.join(data, expid, f'{frame}-r{spectro}-{expid}.fits')
+            r_fib = fitsio.read(filename, columns=['OBJTYPE','DESI_TARGET','FIBER'], ext='FIBERMAP')
 #            bool_array = get_spectrum_objname(r_fib['OBJTYPE'], r_fib['DESI_TARGET']) == nm
             bool_array = r_fib['OBJTYPE'] == obj
             r_fib = r_fib['FIBER']
             r_fib = [r_fib[i] if bool_array[i] else None for i in range(len(r_fib))]
 
-            b_fib = fits.getdata(os.path.join(data, expid, '{}-b{}-{}.fits'.format(frame, spectro, expid)), extname='FIBERMAP')
+            filename = os.path.join(data, expid, f'{frame}-b{spectro}-{expid}.fits')
+            b_fib = fitsio.read(filename, columns=['OBJTYPE','DESI_TARGET','FIBER'], ext='FIBERMAP')
 #            b_fib = b_fib[get_spectrum_objname(b_fib['OBJTYPE'], b_fib['DESI_TARGET']) == nm]['FIBER']
             b_fib = b_fib[b_fib['OBJTYPE'] == obj]['FIBER']
 
-            z_fib = fits.getdata(os.path.join(data, expid, '{}-z{}-{}.fits'.format(frame, spectro, expid)), extname='FIBERMAP')
+            filename = os.path.join(data, expid, f'{frame}-z{spectro}-{expid}.fits')
+            z_fib = fitsio.read(filename, columns=['OBJTYPE','DESI_TARGET','FIBER'], ext='FIBERMAP')
 #            z_fib = z_fib[get_spectrum_objname(z_fib['OBJTYPE'], z_fib['DESI_TARGET']) == nm]['FIBER']
             z_fib = z_fib[z_fib['OBJTYPE'] == obj]['FIBER']
 

--- a/py/nightwatch/plots/spectra.py
+++ b/py/nightwatch/plots/spectra.py
@@ -34,6 +34,30 @@ def downsample(data, n, agg=np.mean):
     return resultx
 
 
+def set_spectrum_objname(objtype, desi_target):
+    '''
+    Convert object type and bit masks from fibermap into a user-friendly string.
+
+    Args:
+        objtype: str such as "TGT," "SKY", or ""
+        desi_target: DESI target bitmask.
+
+    Returns: str corresponding to object type.
+    '''
+    # Extract object type (TGT or SKY) and bitmask info.
+    # Use the first name in the DESI mask, which is the primary category.
+    desinames = desi_mask.names(desi_target)
+    tgtname = desinames[0] if len(desinames) > 0 else 'None'
+
+    objname = 'None'
+
+    if objtype:
+        if 'TGT' in objtype:
+            objname = f'{objtype}: {tgtname}'
+
+    return objname
+
+
 def plot_spectra_spectro(data, expid_num, frame, n, num_fibs=3, height=220, width=240):
     '''
     Produces a gridplot of 10 different spectra plots, each displaying a number of randomly
@@ -354,14 +378,7 @@ def plot_spectra_input(datadir, expid_num, frame, n, select_string, height=500, 
                 # Extract object type (TGT or SKY) and bitmask info.
                 objtype = fibermap['OBJTYPE'][i]
                 desitgt = fibermap['DESI_TARGET'][i]
-                desinms = desi_mask.names(desitgt)
-                tgtname = desinms[0] if len(desinms) > 0 else 'None'
-
-                if not objtype:
-                    objtype = 'None'
-                else:
-                    if 'TGT' in objtype:
-                        objtype = f'{objtype}: {tgtname}'
+                objtype = set_spectrum_objname(objtype, desitgt)
 
                 # Get sky coordinates of the spectrum.
                 ra  = fibermap['TARGET_RA'][i]


### PR DESCRIPTION
PR to address #322, allowing users to see spectra classified by primary `DESI_TARGET` masks rather than just `SKY` or `TGT` from `OBJTYPE`. The change has slowed down the objtype spectrum plots so a bit of optimization could be necessary before merging.