### PR TITLE
Placeholder html files for DARK/ZERO exposures

### DIFF
--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -512,14 +512,16 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
 
     #- Spectra QA page.
     htmlfile = f'{expdir}/qa-spectro-{expid:08d}.html'
-    try:
-        #pc = web_spectra.write_spectra_html(htmlfile, qadata['PER_SPECTRO'], header)
-        qfdir = os.path.join(os.path.abspath(basedir), dirnight)
-        pc = web_spectra.write_spectra_html(htmlfile, qadata, header, qfdir)
-        print(f'Wrote {htmlfile}')
-    except Exception as err:
-        web_placeholder.handle_failed_plot(htmlfile, header, 'PER_SPECTRO')
-
+    if 'PER_SPECTRO' in qadata:
+        try:
+            pc = web_spectra.write_spectra_html(htmlfile, qadata['PER_SPECTRO'], header)
+            qfdir = os.path.join(os.path.abspath(basedir), dirnight)
+            #pc = web_spectra.write_spectra_html(htmlfile, qadata, header, qfdir)
+            print(f'Wrote {htmlfile}')
+        except Exception as err:
+            web_placeholder.handle_failed_plot(htmlfile, header, 'PER_SPECTRO')
+    else:
+        pc = web_placeholder.write_placeholder_html(htmlfile, header, "PER_SPECTRO")
     #- QA summary page.
     htmlfile = f'{expdir}/qa-summary-{expid:08d}.html'
     web_summary.write_summary_html(htmlfile, qadata, preprocdir)

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -498,6 +498,10 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
             web_placeholder.handle_failed_plot(htmlfile, header, "PER_CAMFIBER")
     else:
         pc = web_placeholder.write_placeholder_html(htmlfile, header, "PER_CAMFIBER")
+        fp_file = f'{expdir}/qa-camfiber-{expid:08d}-focalplane_plots.html'
+        pc = web_placeholder.write_placeholder_html(fp_file, header, "PER_CAMFIBER")
+        pa_file = f'{expdir}/qa-camfiber-{expid:08d}-posacc_plots.html'
+        pc = web_placeholder.write_placeholder_html(pa_file, header, "PER_CAMFIBER")
 
     #- Camera QA page: plots of qproc trace shifts, etc.
     htmlfile = f'{expdir}/qa-camera-{expid:08d}.html'
@@ -522,6 +526,7 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
             web_placeholder.handle_failed_plot(htmlfile, header, 'PER_SPECTRO')
     else:
         pc = web_placeholder.write_placeholder_html(htmlfile, header, "PER_SPECTRO")
+
     #- QA summary page.
     htmlfile = f'{expdir}/qa-summary-{expid:08d}.html'
     web_summary.write_summary_html(htmlfile, qadata, preprocdir)


### PR DESCRIPTION
This branch solves [this issue](https://github.com/desihub/nightwatch/issues/337) by adding standard placeholders for the exposures without spectrograph data (DARK and ZERO) in various QA webpages