### PR TITLE
Fall back to older darks if not found.

### DIFF
--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -313,7 +313,6 @@ def run_qproc(rawfile, outdir, ncpu=None, cameras=None):
         log.info('Creating {}'.format(outdir))
         os.makedirs(outdir, exist_ok=True)
 
-
     hdr = fitsio.read_header(rawfile, 0)
     if ( 'OBSTYPE' not in hdr ) and ( 'FLAVOR' not in hdr ) :
         log.warning("no obstype nor flavor keyword in first hdu header, moving to the next one")
@@ -379,11 +378,8 @@ def run_qproc(rawfile, outdir, ncpu=None, cameras=None):
         )
 
         # Set up the qproc command call.
-        cmd = "desi_qproc -i {rawfile} --fibermap {fibermap} --auto --auto-output-dir {outdir} --cam {camera}".format(**outfiles)
+        cmd = "desi_qproc -i {rawfile} --fibermap {fibermap} --auto --auto-output-dir {outdir} --cam {camera} --fallback-on-dark-not-found".format(**outfiles)
         cmdlist.append(cmd)
-
-        # qproc should fall back to an older dark when one is not found.
-        cmdlist.append('--fallback-on-dark-not-found')
 
         # Set up qproc logging.
         loglist.append(outfiles['logfile'])

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -273,11 +273,8 @@ def run_preproc(rawfile, outdir, fibermap=None, ncpu=None, cameras=None):
 
     arglist = list()
 
-    # Preproc should fall back to a previous dark if one is not found.
-    arglist.append('--fallback_on_dark_not_found')
-
     for camera in cameras:
-        args = ['--infile', rawfile, '--outdir', outdir, '--fibermap', fibermap, '--cameras', camera]
+        args = ['--infile', rawfile, '--outdir', outdir, '--fibermap', fibermap, '--cameras', camera, '--fallback-on-dark-not-found']
         arglist.append(args)
 
     ncpu = min(len(arglist), get_ncpu(ncpu))

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -272,6 +272,12 @@ def run_preproc(rawfile, outdir, fibermap=None, ncpu=None, cameras=None):
     header = fitsio.read_header(rawfile, 0)
 
     arglist = list()
+
+    arglist.append('--fail-on-dark-not-found')
+
+    # Preproc should fall back to a previous dark if one is not found.
+    arglist.append('--fallback_on_dark_not_found')
+
     for camera in cameras:
         args = ['--infile', rawfile, '--outdir', outdir, '--fibermap', fibermap, '--cameras', camera]
         arglist.append(args)
@@ -377,8 +383,14 @@ def run_qproc(rawfile, outdir, ncpu=None, cameras=None):
             camera = camera
         )
 
+        # Set up the qproc command call.
         cmd = "desi_qproc -i {rawfile} --fibermap {fibermap} --auto --auto-output-dir {outdir} --cam {camera}".format(**outfiles)
         cmdlist.append(cmd)
+
+        # qproc should fall back to an older dark when one is not found.
+        cmdlist.append('--fallback-on-dark-not-found')
+
+        # Set up qproc logging.
         loglist.append(outfiles['logfile'])
         msglist.append('qproc {}/{} {}'.format(night, expid, camera))
 

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -273,8 +273,6 @@ def run_preproc(rawfile, outdir, fibermap=None, ncpu=None, cameras=None):
 
     arglist = list()
 
-    arglist.append('--fail-on-dark-not-found')
-
     # Preproc should fall back to a previous dark if one is not found.
     arglist.append('--fallback_on_dark_not_found')
 


### PR DESCRIPTION
Update to handle new behavior of `desispec`, which now fails by default if an appropriate dark is not found. This fix ensures that `preproc` and `qproc` will fall back to an older dark calibration rather than raising an exception. Addresses #379.