### PR TITLE
Update deprecation warnings to scripts.

### DIFF
--- a/py/nightwatch/calib_files/calc_arclines.py
+++ b/py/nightwatch/calib_files/calc_arclines.py
@@ -138,6 +138,8 @@ def calc_arc_lines(datadir, night, expids, prog, wavelengths, warnlevel=0.075, e
 
 
 if __name__ == '__main__':
+    print('\033[91m\n** WARNING** : script eprecated. Use gen_arc_refs.py\033[0m\n')
+
     p = ArgumentParser(usage='{prog} [options]',
                        formatter_class=ArgumentDefaultsHelpFormatter)
     p.add_argument('-n', '--nightexpids', type=str,

--- a/py/nightwatch/calib_files/calc_flats.py
+++ b/py/nightwatch/calib_files/calc_flats.py
@@ -108,7 +108,7 @@ def calc_flats(datadir, night, expids, prog, warnlevel=0.01, errlevel=0.02):
 
 
 if __name__ == '__main__':
-    print('\n** WARNING ** This program is deprecated; use gen_flats.py\n')
+    print('\033[91m\n** WARNING** : script eprecated. Use gen_flat_refs.py\033[0m\n')
 
     p = ArgumentParser(usage='{prog} [options]',
                        formatter_class=ArgumentDefaultsHelpFormatter)


### PR DESCRIPTION
Add deprecation warnings for `cal_arclines.py` and `cal_flats.py` but do not delete these yet.