### PR TITLE
Hack to enable processing of spec tests.

### DIFF
--- a/py/nightwatch/qa/runner.py
+++ b/py/nightwatch/qa/runner.py
@@ -71,8 +71,13 @@ class QARunner(object):
                     obstype = hdr['FLAVOR'].strip()
 
                 if this_obstype == "ARC" or this_obstype == "FLAT" \
-                   or this_obstype  == "TESTARC" or this_obstype == "TESTFLAT" :
+                   or this_obstype  == "TESTARC" or this_obstype == "TESTFLAT" \
+                   or this_obstype == "OTHER" :
                     obstype = this_obstype
+
+                    if obstype == "OTHER":
+                        obstype = "TESTFLAT"
+
                     # we use this so we exit the loop
                     break
                 elif obstype == None :


### PR DESCRIPTION
Update from March that enables processing of spec_tests with obstype `OTHER`. Been running at KPNO but not committed to NERSC.