### PR TITLE
More robust error handling for wget file transfer.

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -4,7 +4,7 @@
 
 ### Major Updates
 
-* Added error handling to wget in DESI_SPECTRO_DARK sync script ([PR #461](https://github.com/desihub/nightwatch/pull/461)).
+* Added error handling to wget in DESI_SPECTRO_DARK sync script ([PR #461](https://github.com/desihub/nightwatch/pull/461), [PR #462](https://github.com/desihub/nightwatch/pull/462)).
 * Updated LED flat fielding temperature correction coefficients ([PR #456](https://github.com/desihub/nightwatch/pull/456)).
 
 ### Minor Updates

--- a/etc/sync_desi_spectro_dark.sh
+++ b/etc/sync_desi_spectro_dark.sh
@@ -55,7 +55,7 @@ for csv in bias_table dark_table exp_daily_dark exp_dark_zero; do
         echo "wget FAILED to retrief ${csvfile}."
     else
         #- Copy the CSV file.
-        cp ${tmpdir}/${csvfile} .
+        mv -f ${tmpdir}/${csvfile} .
     fi
 done
 rm -rf ${tmpdir}

--- a/etc/sync_desi_spectro_dark.sh
+++ b/etc/sync_desi_spectro_dark.sh
@@ -52,7 +52,7 @@ for csv in bias_table dark_table exp_daily_dark exp_dark_zero; do
 
     if [ ${rc} -ne 0 ]; then
         #- When wget fails, just emit a warning.
-        echo "wget FAILED to retrief ${csvfile}."
+        echo "wget FAILED to retrieve ${csvfile}."
     else
         #- Copy the CSV file.
         mv -f ${tmpdir}/${csvfile} .

--- a/etc/sync_desi_spectro_dark.sh
+++ b/etc/sync_desi_spectro_dark.sh
@@ -36,30 +36,28 @@ for folder in dark_frames bias_frames; do
     echo `date --utc`
 done
 
-#- Get top-level CSV records
+#- Get top-level CSV records. Download CSV files to a temporary location.
+cd ${DESI_SPECTRO_DARK}/${VERSION}
+tmpdir=tmp-sync-`date "+%Y%m%d"`
+mkdir -p ${tmpdir}
+
 for csv in bias_table dark_table exp_daily_dark exp_dark_zero; do
     csvfile=${csv}.csv
-
-    #- Make a copy of the file in case of download problems.
-    if [ -s ${csvfile} ]; then
-        cp ${csvfile} ${csvfile}.bak
-    fi
     echo "Downloading ${csvfile} from ${URL}$"
 
-    cd ${DESI_SPECTRO_DARK}/${VERSION}
-
+    pushd ${tmpdir}
     wget --user=${user} --password=${passwd} --no-check-certificate ${URL}/${csvfile} -O ${csvfile}
-    if [ $? -ne 0 ]; then
-        #- When wget fails, restore the CSV file from its backup.
-        echo "wget FAILED for ${csvfile}."
-        if [ -s ${csvfile}.bak ]; then
-            echo "Restoring backup ${csvfile}."
-            mv ${csvfile}.bak ${csvfile}
-        fi
+    rc=$?
+    popd
+
+    if [ ${rc} -ne 0 ]; then
+        #- When wget fails, just emit a warning.
+        echo "wget FAILED to retrief ${csvfile}."
     else
-        #- Remove the backup CSV file under all other conditions.
-        rm -f ${csvfile}.bak
+        #- Copy the CSV file.
+        cp ${tmpdir}/${csvfile} .
     fi
 done
+rm -rf ${tmpdir}
 
 echo `date --utc`


### PR DESCRIPTION
Address comment by @sbailey in #458, by downloading CSV tables to a temporary folder and copying them to the top level of DESI_SPECTRO_DARK only if the download is successful.