### PR TITLE
Force use of spawn in parallel threads.

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -4,6 +4,7 @@
 
 ### Major Updates
 
+* Force use of spawn in parallel threads ([PR #464](https://github.com/desihub/nightwatch/pull/464)).
 * Fix broken fibermap assembly due to undefined environment ([PR #463](https://github.com/desihub/nightwatch/pull/463)).
 * Added error handling to wget in DESI_SPECTRO_DARK sync script ([PR #461](https://github.com/desihub/nightwatch/pull/461), [PR #462](https://github.com/desihub/nightwatch/pull/462)).
 * Updated LED flat fielding temperature correction coefficients ([PR #456](https://github.com/desihub/nightwatch/pull/456)).

--- a/py/nightwatch/run.py
+++ b/py/nightwatch/run.py
@@ -593,6 +593,7 @@ def make_plots(infile, basedir, preprocdir=None, logdir=None, rawdir=None, camer
         argslist = [(pinput.format(cam, expid), output.format(cam, expid), downsample, night) for cam in cameras]
 
         if ncpu > 1:
+            mp.set_start_method("spawn", force=True)
             pool = mp.Pool(ncpu)
             pool.starmap(web_plotimage.write_image_html, argslist)
             pool.close()


### PR DESCRIPTION
This PR addresses #459. At KPNO, the creation of parallel jobs to produce CCD plots from `preproc` hangs unless we explicitly force the `multiprocessing` library to call `spawn`.

By default on Linux, `multiprocessing` should call `fork`, which is supposed to be faster because it uses the memory of the parent process, whereas `spawn` starts a new child process from scratch. However, `spawn` is supposed to be safer/more robust. So I think I'm comfortable with this change, and I tested it at KPNO. I will check the behavior at NERSC before merging.