### PR TITLE
Find raw data (FVC images) when not in batch mode.

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -12,6 +12,7 @@
 
 ### Minor Updates
 
+* Ensure that FVC images are plotted at KPNO ([PR #481](https://github.com/desihub/nightwatch/pull/481)).
 * Fixed string literal insertion error in SQLite3 ([PR #478](https://github.com/desihub/nightwatch/pull/478) and [PR #479](https://github.com/desihub/nightwatch/pull/479)).
 * Cosmetic fixes to charge histograms and documentation links ([PR #450](https://github.com/desihub/nightwatch/pull/450)).
 

--- a/py/nightwatch/script.py
+++ b/py/nightwatch/script.py
@@ -141,6 +141,8 @@ def main_monitor(options=None):
         night, expid = expdir.split('/')[-2:]
         night = int(night)
         rawfile = os.path.join(expdir, 'desi-{}.fits.fz'.format(expid))
+        rawdir = os.path.dirname(rawfile)
+
         if expdir not in processed and os.path.exists(rawfile):
             processed.add(expdir)
             outdir = '{}/{}/{}'.format(args.outdir, night, expid)
@@ -181,8 +183,7 @@ def main_monitor(options=None):
                     tmpdir = '{}/{}/{}'.format(args.plotdir, night, expid)
                     if not os.path.isdir(tmpdir) :
                         os.makedirs(tmpdir)
-                    run.make_plots(infile=qafile, basedir=args.plotdir, preprocdir=outdir, logdir=outdir,
-                                   cameras=cameras)
+                    run.make_plots(infile=qafile, basedir=args.plotdir, preprocdir=outdir, logdir=outdir, rawdir=rawdir, cameras=cameras)
 
                     print('{} Updating night/exposure summary tables'.format(time.strftime('%H:%M')))
                     run.write_tables(args.outdir, args.plotdir, expnights=[night,])


### PR DESCRIPTION
Fix for #480. The issue was that a call to `run.make_plots` used at KPNO was missing the `rawdir` argument.