### PR TITLE
Clean up exposure folders at KPNO older than 1 yr.

### DIFF
--- a/etc/kpno_nightwatch_cleanup.sh
+++ b/etc/kpno_nightwatch_cleanup.sh
@@ -40,3 +40,13 @@ EOF
 
 export -f clean_preproc
 find /exposures/nightwatch/20?????? -name \*preproc-\*.html -mtime +14 -exec bash -c 'clean_preproc "$1"' _ {} \;
+
+#- Delete exposure folders older than 1 year. A "manual" approach is being used because the find command has a tendency to hang without exiting.
+for ymd in `\ls /exposures/nightwatch | grep -E "^20[0-9]{6}$"`; do
+    let delta=(`date +%s`-`date +%s -d ${ymd}`)/86400
+    if [ ${delta} -gt 365 ]; then
+        if [ -d /exposures/nightwatch/${ymd} ]; then
+            rm -rf /exposures/nightwatch/${ymd}
+        fi
+    fi
+done


### PR DESCRIPTION
Fix for #493. Deletion of old folders in `/exposures/nightwatch` is not using the `find` command. Tests showed that `find` piped to `xargs` was hanging, probably due to the size of the arg list.